### PR TITLE
playerprops: kernel-state fallback for FEL on CoreELEC NO branch

### DIFF
--- a/playerprops.py
+++ b/playerprops.py
@@ -192,35 +192,85 @@ def get_HdrTypeVar():
     return val
     
     
+# --- Optional fallback for CoreELEC NO-branch (S905X4/S905X5) + Kodi 22 ---
+# On some hardware/branch combos (notably Ugoos AM9 Pro / S905X5 on Piers nightly
+# with jellyfin-kodi stream-mode playback), Kodi's `VideoPlayer.HdrDetail` infolabel
+# returns an empty string during DV Profile 7 playback even though the kernel-side
+# DV pipeline is fully active (verified via /sys/class/amdolby_vision/* and dmesg).
+# This helper provides a kernel-state fallback that only confirms FEL when the
+# Amlogic kernel actively logs `enable_fel 1` + `enable_mel 1` (which fire together
+# for Profile 7 FEL). It does NOT try to distinguish Profile 7 MEL from Profile 8
+# because both produce the same both-zero pattern on this branch.
+
+_FEL_CACHE = {"ts": 0, "fel": None}
+
+
+def _get_fel_from_dmesg():
+    """Most-recent enable_fel/enable_mel state from kernel ring buffer.
+    Returns True only if both signals are 1 (confirmed Profile 7 FEL).
+    Cached 5 seconds to avoid hammering dmesg during the 1s poll loop."""
+    import subprocess, time
+    now = time.time()
+    if now - _FEL_CACHE["ts"] < 5:
+        return _FEL_CACHE["fel"]
+    try:
+        out = subprocess.run(
+            ["dmesg"], capture_output=True, text=True, timeout=2
+        ).stdout
+        fel = mel = None
+        for line in reversed(out.splitlines()):
+            if "enable_fel " in line and fel is None:
+                fel = line.split("enable_fel ")[-1].split()[0] == "1"
+            if "enable_mel " in line and mel is None:
+                mel = line.split("enable_mel ")[-1].split()[0] == "1"
+            if fel is not None and mel is not None:
+                break
+        confirmed = fel is True and mel is True
+        _FEL_CACHE.update({"ts": now, "fel": confirmed})
+        return confirmed
+    except Exception:
+        return None
+
+
 def get_HdrDetailVar():
     raw = _info("VideoPlayer.HdrDetail")
-    if not raw:
-        return ""
 
-    lines = str(raw).splitlines()
-    out = []
+    # Primary path: Kodi populates HdrDetail (NG-branch / Kodi 21 / direct paths).
+    # Format is typically "7FEL" / "7MEL" — color-code the suffix.
+    if raw:
+        lines = str(raw).splitlines()
+        out = []
 
-    for line in lines:
-        line = line.strip()
+        for line in lines:
+            line = line.strip()
 
-        match = re.match(r"(\d+)(FEL|MEL)", line)
-        if match:
-            num, typ = match.groups()
+            match = re.match(r"(\d+)(FEL|MEL)", line)
+            if match:
+                num, typ = match.groups()
 
-            if typ == "FEL":
-                color = "palegreen"
-            elif typ == "MEL":
-                color = "orange"
+                if typ == "FEL":
+                    color = "palegreen"
+                elif typ == "MEL":
+                    color = "orange"
+                else:
+                    color = "white"
+
+                out.append(f"{num} [COLOR {color}]{typ}[/COLOR]")
             else:
-                color = "white"
+                out.append(line)
 
-            out.append(f"{num} [COLOR {color}]{typ}[/COLOR]")
-        else:
-            out.append(line)
+        return "\n".join(out)
 
-    return "\n".join(out)
-    
-    
+    # Fallback for NO-branch / Kodi 22 / stream-mode playback where Kodi's
+    # HdrDetail label stays empty. Only confirms FEL when kernel signals are
+    # unambiguous; stays silent for MEL/Profile 8 since they cannot be reliably
+    # distinguished from the kernel state on this branch.
+    if "dolby" in str(_info("VideoPlayer.HdrType")).lower():
+        if _get_fel_from_dmesg() is True:
+            return "7 [COLOR palegreen]FEL[/COLOR]"
+
+    return ""
+
 def get_ModeVar():
     val = _info("Player.Process(amlogic.eoft_gamut)")
 


### PR DESCRIPTION
## Summary

Adds a small kernel-state fallback in `get_HdrDetailVar()` so the overlay correctly shows `Dolby Vision Profile 7 FEL` on CoreELEC NO-branch builds (S905X4/S905X5, kernel 5.15.x, Kodi 22) where `VideoPlayer.HdrDetail` returns an empty string during Profile 7 playback.

Primary code path is unchanged. The fallback only runs when:
- `VideoPlayer.HdrDetail` is empty, AND
- `VideoPlayer.HdrType` already reports `dolbyvision`

In that case the helper reads `dmesg` for the most recent `enable_fel 1` / `enable_mel 1` kernel events (Amlogic DV driver fires these when Profile 7 EL processing engages). If both are confirmed `1`, the fallback returns the same `7 [COLOR palegreen]FEL[/COLOR]` string the primary path produces on NG branch.

## Why

Verified on Ugoos AM9 Pro (S905X5) running official Piers nightly 20260516, kernel 5.15.196, with the community patched dovi.ko overlay at `/flash/dovi.ko`. During DV Profile 7 FEL playback (UHD BD remuxes with `el_type=FEL` confirmed via `dovi_tool info`):

```
VideoPlayer.HdrType            "dolbyvision"
VideoPlayer.HdrDetail          ""               <- empty, the bug
/sys/class/amdolby_vision/dv_mode      IPT_TUNNEL
/sys/class/amdolby_vision/src_format   vd1(inst1): DV FORMAT_DOVI
dmesg                                  enable_fel 1, enable_mel 1
```

The kernel-side DV pipeline runs cleanly and FEL is genuinely active — Kodi's `VideoPlayer.HdrDetail` infolabel just doesn't get populated by the demuxer/parser in stream-mode playback on NO branch. With this fallback, the overlay shows the correct value during these sessions; on NG-branch hardware where the label is already populated, the fallback is never reached and the overlay is unchanged.

## What it intentionally does NOT do

- **No MEL claim.** Profile 7 MEL on NO branch leaves both `enable_fel` and `enable_mel` at 0 in dmesg — same signature as Profile 8 and Profile 5 — so the kernel state alone can't reliably distinguish them. Staying silent rather than guessing.
- **No Profile 8 / Profile 5 claim.** Same reason.
- **No /sys/class/amdolby_vision/ poll.** Looked at it, but `src_format` and `dv_inst_status` were less reliable than the dmesg events as a FEL signal — `dvbldec dvbldec2` (the two-decoder string) appears for any DV profile, not just FEL.

## Safety / cost

- **5-second result cache** so the 1-second poll loop in `default.py` doesn't re-shell `dmesg` on every tick. Measured cost: a single `dmesg` read is ~50 ms on the test hardware; cached reads are essentially free.
- **2-second subprocess timeout** on the dmesg call.
- **Errors swallowed** (returns `None` → falls back to current empty-string behavior).
- **No new dependencies** — only stdlib `subprocess` and `time`.
- **Kernel `dmesg_restrict`**: if the kernel restricts dmesg from unprivileged users, the subprocess returns empty stdout and the fallback returns `""` — same as today's behavior, no regression.

## Test plan

- [x] Apply on real AM9 Pro / S905X5 / Piers nightly 20260516 setup, play a known Profile 7 FEL UHD remux via jellyfin-kodi stream mode, confirm overlay shows `Dolby Vision Profile 7 FEL` (green).
- [x] Play a known Profile 7 MEL UHD remux, confirm overlay shows `Dolby Vision Profile` only — no false FEL claim.
- [x] Play a known Profile 8 movie, confirm overlay shows `Dolby Vision Profile` only — no false FEL claim.
- [x] Confirm dialog still opens and updates at the 1-second cadence (cache is doing its job).
- [ ] Verify on NG-branch hardware (S922X / p3i) that the fallback is never reached and the overlay behavior is unchanged. (Cannot test locally — would appreciate maintainer or NG-branch user confirmation.)

## Notes

- Screenshots circulating from NG-branch + direct-paths users show the addon working as designed there — `Dolby Vision Profile 7 FEL` rendered correctly. This PR doesn't touch that path; only adds the kernel-state safety net for hosts where Kodi's label is empty.
- The longer-term fix would be at the CoreELEC level — wiring `VideoPlayer.HdrDetail` to populate on NO branch the same way it does on NG. This is just a graceful degradation in TinyPPI until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)