### PR TITLE
Fix DV detection crash on non-ASCII paths under C locale

### DIFF
--- a/resources/lib/dvinfo.py
+++ b/resources/lib/dvinfo.py
@@ -629,7 +629,13 @@ def _run_hdrprobe(probe: str, src: str) -> dict | None:
             [probe, "--json", src],
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            text=True,
+            # Decode explicitly as UTF-8 rather than the process locale, which is
+            # C/POSIX (ASCII) under Kodi/CoreELEC.  hdrprobe echoes the source
+            # path back in its JSON, so an accented filename (e.g. "Léon") makes a
+            # locale-based decode raise UnicodeDecodeError before parsing begins;
+            # errors="replace" keeps any stray non-UTF-8 byte from aborting too.
+            encoding="utf-8",
+            errors="replace",
         ).stdout
     except OSError as exc:
         _log(f"DV: hdrprobe failed to start: {exc}", xbmc.LOGWARNING)


### PR DESCRIPTION
hdrprobe echoes the source path back in its JSON output, so playing a file whose path contains accented characters (e.g. "Léon") crashed DV content-mapping detection with:

  DV CM detection failed: 'ascii' codec can't decode byte 0xc3 in
  position 81: ordinal not in range(128)

subprocess.run(..., text=True) decodes stdout using the process locale's preferred encoding, which is C/POSIX (ASCII) under Kodi/CoreELEC. The UTF-8 bytes of the accented path (0xc3 ...) then fail to decode before the JSON is ever parsed. Windows defaults to UTF-8, hence it worked there.

Decode hdrprobe's output explicitly as UTF-8 with errors="replace" instead of relying on the locale.