### PR TITLE
Preload playback metadata detection at video start

### DIFF
--- a/resources/lib/dvinfo.py
+++ b/resources/lib/dvinfo.py
@@ -635,6 +635,45 @@ def _worker(path: str, session_token: str) -> None:
             _inflight.discard(path)
 
 
+def _start_worker(path: str, session_token: str) -> bool:
+    """Spawn the background detection worker for ``path`` unless one is already
+    in flight for it.  Returns True when a new worker was started."""
+    with _lock:
+        if path in _inflight:
+            return False
+        _inflight.add(path)
+
+    threading.Thread(
+        target=_worker,
+        args=(path, session_token),
+        daemon=True,
+    ).start()
+    return True
+
+
+def prime_playback_detection() -> bool:
+    """Kick off DV / audio detection for the currently playing file ahead of time.
+
+    Called from the background service at playback start so the hdrprobe and
+    audio-bitstream scan finish while the video plays, leaving the result cached
+    before the overlay is ever opened.  Non-blocking; a no-op when nothing is
+    playing or a result is already cached / in flight.  Returns True when a new
+    detection worker was started.
+    """
+    try:
+        path = xbmc.Player().getPlayingFile()
+    except RuntimeError:
+        return False
+    if not path:
+        return False
+
+    session_token = _session_token()
+    if _read_cached_info(path, session_token) is not None:
+        return False
+
+    return _start_worker(path, session_token)
+
+
 def _get_info_status_value(key: str) -> tuple[str, str]:
     """Non-blocking.  Return one cached DV metadata field for the current file,
     starting background detection on first call.
@@ -655,16 +694,7 @@ def _get_info_status_value(key: str) -> tuple[str, str]:
         value = cached_info.get(key, "")
         return value, "ready" if value else "failed"
 
-    with _lock:
-        if path in _inflight:
-            return "", "fetching"
-        _inflight.add(path)
-
-    threading.Thread(
-        target=_worker,
-        args=(path, session_token),
-        daemon=True,
-    ).start()
+    _start_worker(path, session_token)
     return "", "fetching"
 
 

--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -13,7 +13,7 @@ _LIB_PATH = os.path.dirname(__file__)
 if _LIB_PATH not in sys.path:
     sys.path.insert(0, _LIB_PATH)
 
-from dvinfo import reset_playback_cache
+from dvinfo import prime_playback_detection, reset_playback_cache
 from theme import apply_theme
 
 _ADDON_ID = "script.tinyppi"
@@ -42,8 +42,8 @@ def _notification_media_type(data: str) -> str:
 
 
 class KodiMonitor(xbmc.Monitor):
-    """Listens for Kodi notifications; resets the DV cache on stop and fires the
-    splash on playback start."""
+    """Listens for Kodi notifications; resets the DV cache on stop and, on
+    playback start, preloads the metadata detection and fires the splash."""
 
     def onNotification(self, sender: str, method: str, data: str) -> None:
         if method == "Player.OnStop":
@@ -51,6 +51,7 @@ class KodiMonitor(xbmc.Monitor):
             _log("Dolby Vision playback cache cleared")
 
         if method == "Player.OnAVStart":
+            self._prime_detection()
             self._maybe_show_splash()
 
         try:
@@ -67,6 +68,21 @@ class KodiMonitor(xbmc.Monitor):
         start, so enabling one here starts it without restarting playback.
         """
         self._maybe_show_splash()
+
+    def _prime_detection(self) -> None:
+        """Start hdrprobe / audio detection as soon as a video begins playing.
+
+        Runs the same background scan the overlay would trigger lazily, so the
+        Dolby Vision, HDR and audio metadata are already cached and shown
+        instantly when the overlay (or dialog mode) is opened — no ``Fetching...``.
+        """
+        try:
+            if not xbmc.getCondVisibility("Player.HasVideo"):
+                return
+            if prime_playback_detection():
+                _log("Preloading playback metadata in background")
+        except Exception as exc:
+            _log(f"Exception priming detection: {exc}", xbmc.LOGERROR)
 
     def _maybe_show_splash(self) -> None:
         """Fire the format-logo splash when enabled for this video.


### PR DESCRIPTION
Trigger the hdrprobe and audio-bitstream scan from the background service on Player.OnAVStart instead of only lazily when the overlay first reads a property. The result is cached while the video plays, so the Dolby Vision, HDR and audio fields are already populated when the TinyPPI overlay (or dialog mode) opens — no more "Fetching..." on open.

- dvinfo: extract _start_worker() and add public prime_playback_detection()
- monitor: prime detection on Player.OnAVStart when a video is playing