### PR TITLE
Document codec logos in README and dedupe splash removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,62 @@ plugin://script.tinyppi/
 
 ---
 
+## Codec Logos
+
+TinyPPI can display the current **video (HDR) and audio format** as stacked logos
+directly on the video window during playback. The video/HDR logo sits on top, the
+audio logo below it, on a rounded panel whose colors and opacity are fully themeable
+in the add-on settings. The logos are re-resolved live, so switching the audio track
+updates the audio logo on the fly.
+
+You can enable the logos in three independent situations (**Settings → Codec Logos**):
+
+- **On playback start** — shown for the first few seconds after a video starts
+  (duration configurable).
+- **While the Video OSD is open** — shown whenever the player OSD is visible.
+- **While the TinyPPI overlay is open** — shown alongside the info overlay.
+
+For each situation the horizontal/vertical position and the size can be adjusted
+separately.
+
+### Supported formats
+
+**Video / HDR**
+
+| Logo | Format |
+|------|--------|
+| SDR | Standard Dynamic Range |
+| HDR10 | HDR10 |
+| HDR10+ | HDR10+ |
+| HLG | Hybrid Log-Gamma |
+| Dolby Vision | Dolby Vision |
+
+**Audio**
+
+| Logo | Format |
+|------|--------|
+| AAC | AAC (incl. HE-AAC) |
+| Dolby Digital | Dolby Digital (AC-3) |
+| Dolby Digital Plus | Dolby Digital Plus (E-AC-3) |
+| Dolby Digital Plus Atmos | Dolby Digital Plus with Dolby Atmos |
+| Dolby TrueHD | Dolby TrueHD |
+| Dolby TrueHD Atmos | Dolby TrueHD with Dolby Atmos |
+| DTS | DTS (incl. DTS Express) |
+| DTS 96/24 | DTS 96/24 |
+| DTS-ES | DTS-ES |
+| DTS-HD HRA | DTS-HD High Resolution Audio |
+| DTS-HD MA | DTS-HD Master Audio |
+| DTS:X | DTS:X |
+| IMAX | DTS:X IMAX Enhanced |
+| FLAC | FLAC |
+| PCM | PCM / LPCM |
+| MP3 | MP3 |
+| OPUS | Opus |
+
+Formats without a matching logo simply omit the audio image.
+
+---
+
 ## Advanced Launch Arguments
 
 TinyPPI supports additional arguments to open specific modes or apply VS10 output modes directly — without opening the overlay or the dialog first.

--- a/resources/lib/splash.py
+++ b/resources/lib/splash.py
@@ -722,11 +722,7 @@ def _fade_out(video_window, home, monitor, mode: str, controls) -> None:
     """Fade *controls* out (condition true→false), await it, remove them."""
     home.clearProperty(_MODE_VISIBLE_PROPS[mode])
     monitor.waitForAbort(_FADE_OUT_SECONDS)
-    try:
-        video_window.removeControls(controls)
-    except Exception:
-        # The video window may already be gone; a failed removal is harmless.
-        pass
+    _remove_controls(video_window, controls)
 
 
 def open_splash() -> None:


### PR DESCRIPTION
- Add a "Codec Logos" section to the README describing the format-logo overlay (video/HDR + audio), its three display triggers, and the full list of supported video and audio formats.
- splash.py: have _fade_out delegate its control removal to the existing _remove_controls helper instead of repeating the try/except block.