### PR TITLE
Stream media into hdrprobe over stdin, without temp chunk files

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tinyppi" name="TinyPPI" version="1.9.2" provider-name="jamal2362">
+<addon id="script.tinyppi" name="TinyPPI" version="1.9.3" provider-name="jamal2362">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="tools.tinyppi" version="1.1.2"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tinyppi" name="TinyPPI" version="1.9.1" provider-name="jamal2362">
+<addon id="script.tinyppi" name="TinyPPI" version="1.9.2" provider-name="jamal2362">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="tools.tinyppi" version="1.1.2"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tinyppi" name="TinyPPI" version="1.8.9" provider-name="jamal2362">
+<addon id="script.tinyppi" name="TinyPPI" version="1.9.0" provider-name="jamal2362">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="tools.tinyppi" version="1.1.2"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tinyppi" name="TinyPPI" version="1.9.0" provider-name="jamal2362">
+<addon id="script.tinyppi" name="TinyPPI" version="1.9.1" provider-name="jamal2362">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="tools.tinyppi" version="1.1.2"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.tinyppi" name="TinyPPI" version="1.9.3" provider-name="jamal2362">
+<addon id="script.tinyppi" name="TinyPPI" version="1.9.4" provider-name="jamal2362">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="tools.tinyppi" version="1.1.2"/>

--- a/resources/lib/audioprobe.py
+++ b/resources/lib/audioprobe.py
@@ -270,10 +270,15 @@ class AudioStreamScanner:
     (and its full header) is always parsed exactly once: earlier bytes are never
     re-scanned, so nothing is double-counted.  ``finish`` flushes the final tail,
     where the parsers tolerate a truncated last frame.
+
+    The carry buffer is a reused ``bytearray``: each block is appended in place
+    and the scanned prefix is dropped with ``del buf[:limit]``, so a feed copies
+    the block once (into spare capacity, no per-block reallocation) instead of
+    the two copies a ``tail + bytes(block)`` concatenation would make.
     """
 
     def __init__(self):
-        self._tail = b""
+        self._buf = bytearray()
         self._votes: dict[str, dict[str, dict[int, int]]] = {
             family: {} for family, _s, _p in _FAMILIES
         }
@@ -283,23 +288,23 @@ class AudioStreamScanner:
         """Scan the next block of stream bytes."""
         if not block:
             return
-        buf = self._tail + bytes(block)
-        limit = len(buf) - _MAX_LOOKAHEAD
+        self._buf.extend(block)
+        limit = len(self._buf) - _MAX_LOOKAHEAD
         if limit <= 0:
             # Too little to parse anything safely yet; keep accumulating.  Blocks
-            # are far larger than the overlap, so the tail never grows unbounded.
-            self._tail = buf
+            # are far larger than the overlap, so the buffer never grows unbounded
+            # (the scanned prefix is dropped below on every real feed).
             return
-        self._scan(buf, limit)
-        self._tail = buf[limit:]
+        self._scan(self._buf, limit)
+        del self._buf[:limit]
 
     def finish(self) -> None:
         """Scan whatever remains once the stream ends."""
-        if self._tail:
-            self._scan(self._tail, len(self._tail))
-            self._tail = b""
+        if self._buf:
+            self._scan(self._buf, len(self._buf))
+            self._buf = bytearray()
 
-    def _scan(self, buf: bytes, limit: int) -> None:
+    def _scan(self, buf, limit: int) -> None:
         """Count validated syncs starting at ``pos < limit`` in ``buf``."""
         for family, sync, parser in _FAMILIES:
             if self._hits[family] >= _MAX_HITS:

--- a/resources/lib/audioprobe.py
+++ b/resources/lib/audioprobe.py
@@ -1,7 +1,11 @@
 """Source audio bit-depth / sample-rate detection.
 
-Scans the first chunk of the playing file for audio bitstream sync patterns
-and reads the coded source resolution straight from the stream headers:
+Scans the head of the playing stream for audio bitstream sync patterns and
+reads the coded source resolution straight from the stream headers.  The scan
+is incremental (``AudioStreamScanner``): the stream is fed in blocks — the same
+blocks piped into hdrprobe — and never more than one block plus a small overlap
+is held in memory, so no fixed head buffer is needed.  ``scan_audio_streams``
+wraps it for one-shot callers.  The headers read are:
 
 * DTS / DTS-HD:  ``PCMR`` (source PCM resolution) and ``SFREQ`` fields of the
                  core frame header -> depth 16 / 20 / 24 and the sample rate.
@@ -65,6 +69,13 @@ _MLP_QUANTS = {0: 16, 1: 20, 2: 24}
 
 # Enough validated frame headers for an unambiguous majority vote.
 _MAX_HITS = 64
+
+# Longest lookahead any parser needs past a sync position.  The DTS extension
+# substream descriptor is the deepest — its reach is bounded by the substream
+# header size, at most 4 KiB (ETSI TS 102 114); every other parser needs ≤ 42
+# bytes.  8 KiB is a safe overlap so a sync and its whole header always fit
+# inside one scan window, even when the sync straddles a block boundary.
+_MAX_LOOKAHEAD = 8 * 1024
 
 
 class _BitReader:
@@ -236,47 +247,104 @@ def _parse_flac(data: bytes, pos: int) -> dict[str, int] | None:
     return {"depth": bps}
 
 
-def _scan(data: bytes, sync: bytes, parser) -> dict[str, int]:
-    """Return the majority value per metric across all validated ``sync`` hits."""
-    votes: dict[str, dict[int, int]] = {}
-    hits = 0
-    pos = data.find(sync)
-    while pos != -1 and hits < _MAX_HITS:
-        fields = parser(data, pos)
-        if fields:
-            hits += 1
-            for metric, value in fields.items():
-                metric_votes = votes.setdefault(metric, {})
-                metric_votes[value] = metric_votes.get(value, 0) + 1
-        pos = data.find(sync, pos + 1)
+_FAMILIES = (
+    ("dts", _DTS_CORE_SYNC, _parse_dts_core),
+    ("dts_exss", _DTS_EXSS_SYNC, _parse_dts_exss),
+    ("truehd", _TRUEHD_SYNC, _parse_truehd),
+    ("mlp", _MLP_SYNC, _parse_mlp),
+    ("flac", _FLAC_MARKER, _parse_flac),
+)
 
-    return {
-        metric: max(metric_votes, key=metric_votes.get)
-        for metric, metric_votes in votes.items()
-    }
+
+class AudioStreamScanner:
+    """Incremental audio bitstream scanner.
+
+    Fed the stream in arbitrary-sized blocks (typically the same blocks piped
+    into hdrprobe), it searches each for the sync patterns and decides each
+    metric by majority vote — identical to a one-shot scan of the concatenated
+    input — but never holds more than one block plus ``_MAX_LOOKAHEAD`` in
+    memory, so there is no fixed head buffer.
+
+    Each ``feed`` scans the new bytes only up to ``len - _MAX_LOOKAHEAD`` and
+    carries the tail over to the next call, so a sync straddling a block seam
+    (and its full header) is always parsed exactly once: earlier bytes are never
+    re-scanned, so nothing is double-counted.  ``finish`` flushes the final tail,
+    where the parsers tolerate a truncated last frame.
+    """
+
+    def __init__(self):
+        self._tail = b""
+        self._votes: dict[str, dict[str, dict[int, int]]] = {
+            family: {} for family, _s, _p in _FAMILIES
+        }
+        self._hits: dict[str, int] = {family: 0 for family, _s, _p in _FAMILIES}
+
+    def feed(self, block) -> None:
+        """Scan the next block of stream bytes."""
+        if not block:
+            return
+        buf = self._tail + bytes(block)
+        limit = len(buf) - _MAX_LOOKAHEAD
+        if limit <= 0:
+            # Too little to parse anything safely yet; keep accumulating.  Blocks
+            # are far larger than the overlap, so the tail never grows unbounded.
+            self._tail = buf
+            return
+        self._scan(buf, limit)
+        self._tail = buf[limit:]
+
+    def finish(self) -> None:
+        """Scan whatever remains once the stream ends."""
+        if self._tail:
+            self._scan(self._tail, len(self._tail))
+            self._tail = b""
+
+    def _scan(self, buf: bytes, limit: int) -> None:
+        """Count validated syncs starting at ``pos < limit`` in ``buf``."""
+        for family, sync, parser in _FAMILIES:
+            if self._hits[family] >= _MAX_HITS:
+                continue
+            votes = self._votes[family]
+            pos = buf.find(sync)
+            while pos != -1 and pos < limit and self._hits[family] < _MAX_HITS:
+                fields = parser(buf, pos)
+                if fields:
+                    self._hits[family] += 1
+                    for metric, value in fields.items():
+                        metric_votes = votes.setdefault(metric, {})
+                        metric_votes[value] = metric_votes.get(value, 0) + 1
+                pos = buf.find(sync, pos + 1)
+
+    def result(self) -> dict[str, dict[str, int]]:
+        """Return the detected source metrics per codec family, e.g.
+        ``{"dts": {"depth": 24, "rate": 96000}, "flac": {"depth": 16}}``."""
+        streams: dict[str, dict[str, int]] = {}
+        for family, _s, _p in _FAMILIES:
+            votes = self._votes[family]
+            if votes:
+                streams[family] = {
+                    metric: max(metric_votes, key=metric_votes.get)
+                    for metric, metric_votes in votes.items()
+                }
+
+        # The extension substream's asset descriptor is authoritative for the
+        # DTS family: it describes the full extension (e.g. 96/192 kHz XLL),
+        # which the compatibility core header cannot express.
+        exss = streams.pop("dts_exss", None)
+        if exss:
+            merged = streams.get("dts", {})
+            merged.update(exss)
+            streams["dts"] = merged
+        return streams
 
 
 def scan_audio_streams(data: bytes) -> dict[str, dict[str, int]]:
-    """Return the detected source metrics per codec family, e.g.
-    ``{"dts": {"depth": 24, "rate": 96000}, "flac": {"depth": 16}}``."""
-    streams: dict[str, dict[str, int]] = {}
-    for family, sync, parser in (
-        ("dts", _DTS_CORE_SYNC, _parse_dts_core),
-        ("dts_exss", _DTS_EXSS_SYNC, _parse_dts_exss),
-        ("truehd", _TRUEHD_SYNC, _parse_truehd),
-        ("mlp", _MLP_SYNC, _parse_mlp),
-        ("flac", _FLAC_MARKER, _parse_flac),
-    ):
-        result = _scan(data, sync, parser)
-        if result:
-            streams[family] = result
+    """Return the detected source metrics per codec family for one buffer, e.g.
+    ``{"dts": {"depth": 24, "rate": 96000}, "flac": {"depth": 16}}``.
 
-    # The extension substream's asset descriptor is authoritative for the
-    # DTS family: it describes the full extension (e.g. 96/192 kHz XLL),
-    # which the compatibility core header cannot express.
-    exss = streams.pop("dts_exss", None)
-    if exss:
-        merged = streams.get("dts", {})
-        merged.update(exss)
-        streams["dts"] = merged
-    return streams
+    Thin one-shot wrapper over ``AudioStreamScanner`` for callers that already
+    hold the whole head in memory."""
+    scanner = AudioStreamScanner()
+    scanner.feed(data)
+    scanner.finish()
+    return scanner.result()

--- a/resources/lib/dvinfo.py
+++ b/resources/lib/dvinfo.py
@@ -47,10 +47,15 @@ _BLOCK_BYTES = 1024 * 1024
 # How far the audio scan reads when hdrprobe is *not* bounding the read — i.e.
 # for real local files (hdrprobe reads those to EOF on its own) and the rare
 # fallback where hdrprobe is unavailable.  On the stdin path there is no such
-# limit: the scan is bounded by hdrprobe's own budget.  It caps the read
-# distance only; memory stays at one block regardless of this value.  Audio
-# frames are interleaved near the start, well within this window.
-_AUDIO_SCAN_LIMIT = 16 * 1024 * 1024
+# limit: the scan is bounded by hdrprobe's own budget.
+#
+# A container interleaves audio from the very start, so the first audio frames
+# sit within the opening fraction of a second — a few hundred KiB even at UHD
+# Blu-ray bitrates.  A stream's depth / sample rate is constant across all its
+# frames, so a handful of validated frames already settle the majority vote;
+# 4 MiB reaches the first frames and collects many, with generous headroom.
+# This caps the read distance only — peak memory stays at one block.
+_AUDIO_SCAN_LIMIT = 4 * 1024 * 1024
 
 _LABEL_FETCH = 32096
 _LABEL_NA    = 32033

--- a/resources/lib/dvinfo.py
+++ b/resources/lib/dvinfo.py
@@ -4,10 +4,15 @@ Inspects the playing stream with hdrprobe and parses its JSON report into the
 Dolby Vision, Level 5/6 and bit-depth properties consumed by properties.py.
 
 Kodi plays from VFS URLs (nfs://, smb://, http://) that standalone hdrprobe
-cannot open, so the first chunk is copied through xbmcvfs into special://temp/
-and hdrprobe runs on that.  Detection runs once per file in a cached background
-thread so the polling loop never blocks.  CoreELEC only; the hdrprobe binary is
-the aarch64 build in tools.tinyppi (tools/hdrprobe/hdrprobe).
+cannot open, so the stream is piped straight into ``hdrprobe --json -`` over
+stdin (hdrprobe's stdin integration): blocks are read through xbmcvfs and
+written to the probe until it has taken its head budget — the write then fails
+with a broken pipe, the documented success signal — or the stream ends.  Real
+filesystem paths are handed to hdrprobe directly, where it can read to EOF for
+the fullest analysis.  Nothing is copied to a temporary chunk file any more.
+Detection runs once per file in a cached background thread so the polling loop
+never blocks.  CoreELEC only; the hdrprobe binary is the aarch64 build in
+tools.tinyppi (tools/hdrprobe/hdrprobe).
 
 Blu-ray discs are a special case: Kodi hands us the raw ``*.iso`` (whose first
 bytes are the UDF filesystem header, not video), a ``bluray://`` title stream,
@@ -33,12 +38,14 @@ from audioprobe import scan_audio_streams
 
 _ADDON      = xbmcaddon.Addon()
 
-_TEMP_DIR   = xbmcvfs.translatePath("special://temp/")
-_CHUNK_PATH = os.path.join(_TEMP_DIR, "tinyppi_dv.chunk")
+# Blocks piped into hdrprobe's stdin.  hdrprobe decides how much to read (a
+# format-specific head budget), so this is only the VFS read granularity.
+_BLOCK_BYTES = 1024 * 1024
 
-# 16 MiB holds the first GOP (keyframe + RPU) even at UHD Blu-ray bitrates, so
-# hdrprobe finds RPUs to sample; it tolerates the truncated chunk.
-_CHUNK_BYTES  = 16 * 1024 * 1024
+# Head window captured for the audio bitstream scan.  16 MiB holds the first
+# GOP (keyframe + RPU) even at UHD Blu-ray bitrates and sits within hdrprobe's
+# own head budget, so the VFS stream is still read only once.
+_HEAD_BYTES   = 16 * 1024 * 1024
 
 _LABEL_FETCH = 32096
 _LABEL_NA    = 32033
@@ -349,23 +356,32 @@ def _resolve_disc_stream(path: str) -> str:
     return path
 
 
-def _local_source(path: str) -> tuple[str, bool]:
-    """Return ``(local_path, is_temp)``: VFS URLs are partially copied into
-    special://temp/, real filesystem paths are used directly.  Blu-ray images
-    are first resolved to their main-feature ``.m2ts`` inside the disc."""
-    source = _resolve_disc_stream(path)
-    if source.startswith("/"):
-        return source, False
+def _read_vfs_head(vfs_url: str) -> bytes:
+    """Return the first ``_HEAD_BYTES`` of a Kodi VFS stream for the audio scan.
 
-    f = xbmcvfs.File(source)
+    Only used when hdrprobe itself is unavailable; otherwise the head window is
+    captured for free while the stream is piped into the probe (see
+    ``_probe_stream_stdin``), so the stream is never read twice."""
     try:
-        data = f.readBytes(_CHUNK_BYTES)
-    finally:
-        f.close()
+        f = xbmcvfs.File(vfs_url)
+        try:
+            return bytes(f.readBytes(_HEAD_BYTES))
+        finally:
+            f.close()
+    except Exception as exc:
+        _log(f"Audio: VFS head read failed for {vfs_url}: {exc}", xbmc.LOGWARNING)
+        return b""
 
-    with open(_CHUNK_PATH, "wb") as out:
-        out.write(data)
-    return _CHUNK_PATH, True
+
+def _read_local_head(path: str) -> bytes:
+    """Return the first ``_HEAD_BYTES`` of a real filesystem ``path`` for the
+    audio scan, or ``b""`` when it can't be read."""
+    try:
+        with open(path, "rb") as f:
+            return f.read(_HEAD_BYTES)
+    except OSError as exc:
+        _log(f"Audio: head read failed: {exc}", xbmc.LOGWARNING)
+        return b""
 
 
 def _compact_cm_version(value: str) -> str:
@@ -707,10 +723,25 @@ def _parse_probe(data: dict) -> dict[str, str]:
     return info
 
 
+def _decode_report(out: str) -> dict | None:
+    """Parse hdrprobe's JSON report from ``out``, or ``None`` when it holds no
+    decodable report object.  Decoding starts at the first brace so stray
+    leading log text (and hdrprobe's stdin parse warnings) are tolerated."""
+    start = out.find("{")
+    if start == -1:
+        return None
+    try:
+        data, _ = json.JSONDecoder().raw_decode(out[start:])
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _run_hdrprobe(probe: str, src: str) -> dict | None:
-    """Run hdrprobe on ``src`` and return the parsed JSON report, or ``None``.
-    The exit code is ignored (a truncated chunk logs parse errors); only
-    decodable JSON on stdout is required."""
+    """Run hdrprobe on a real filesystem ``src`` and return the parsed report,
+    or ``None``.  Used only for genuine local paths, where hdrprobe opens the
+    file itself and reads to EOF for the fullest analysis; VFS URLs are streamed
+    in over stdin instead (see ``_probe_stream_stdin``)."""
     try:
         out = subprocess.run(
             [probe, "--json", src],
@@ -726,26 +757,72 @@ def _run_hdrprobe(probe: str, src: str) -> dict | None:
         _log(f"DV: hdrprobe failed to start: {exc}", xbmc.LOGWARNING)
         return None
 
-    # Decode from the first brace so stray leading log text is tolerated.
-    start = out.find("{")
-    if start == -1:
-        return None
-    try:
-        data, _ = json.JSONDecoder().raw_decode(out[start:])
-    except ValueError:
-        return None
-    return data if isinstance(data, dict) else None
+    return _decode_report(out)
 
 
-def _scan_audio_streams(src: str) -> tuple[str, str]:
-    """Scan the first chunk of ``src`` for audio bitstreams and serialize the
-    detected source metrics as a ``(depths, rates)`` pair of per-family
-    strings, e.g. ``("dts=24;truehd=24", "dts=96000")`` ('' when none)."""
+def _probe_stream_stdin(probe: str, vfs_url: str) -> tuple[dict | None, bytes]:
+    """Probe a Kodi VFS stream without copying it to disk.
+
+    hdrprobe cannot open nfs:// / smb:// / bluray:// / udf:// / https:// URLs
+    itself, so the stream is piped into ``hdrprobe --json -``: blocks are read
+    through xbmcvfs and written to its stdin until hdrprobe has taken its head
+    budget (the write then fails with a broken pipe — the documented success
+    signal) or the stream ends within budget.  The first ``_HEAD_BYTES`` are
+    captured along the way for the audio scan, so the stream is read only once.
+
+    Returns ``(report, head_bytes)``; ``report`` is ``None`` when hdrprobe
+    emitted no decodable JSON.
+    """
     try:
-        with open(src, "rb") as f:
-            head = f.read(_CHUNK_BYTES)
+        proc = subprocess.Popen(
+            [probe, "--json", "-"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
     except OSError as exc:
-        _log(f"Audio: chunk read failed: {exc}", xbmc.LOGWARNING)
+        _log(f"DV: hdrprobe failed to start: {exc}", xbmc.LOGWARNING)
+        return None, _read_vfs_head(vfs_url)
+
+    head = bytearray()
+    try:
+        f = xbmcvfs.File(vfs_url)
+        try:
+            while True:
+                block = f.readBytes(_BLOCK_BYTES)
+                if not block:
+                    break  # end of stream within hdrprobe's budget
+                if len(head) < _HEAD_BYTES:
+                    head.extend(block[: _HEAD_BYTES - len(head)])
+                try:
+                    proc.stdin.write(block)
+                except (BrokenPipeError, OSError):
+                    break  # hdrprobe took what it needs
+        finally:
+            f.close()
+    except Exception as exc:
+        _log(f"DV: VFS read failed for {vfs_url}: {exc}", xbmc.LOGWARNING)
+
+    # communicate() closes stdin (signalling EOF for short streams) and drains
+    # the small JSON report; hdrprobe writes it only after it stops reading, so
+    # there is no deadlock.
+    try:
+        out, _ = proc.communicate()
+    except Exception as exc:
+        _log(f"DV: hdrprobe did not complete: {exc}", xbmc.LOGWARNING)
+        proc.kill()
+        proc.communicate()
+        return None, bytes(head)
+
+    report = _decode_report(out.decode("utf-8", "replace")) if out else None
+    return report, bytes(head)
+
+
+def _audio_fields(head: bytes) -> tuple[str, str]:
+    """Scan the stream ``head`` for audio bitstreams and serialize the detected
+    source metrics as a ``(depths, rates)`` pair of per-family strings, e.g.
+    ``("dts=24;truehd=24", "dts=96000")`` ('' when none)."""
+    if not head:
         return "", ""
 
     streams = scan_audio_streams(head)
@@ -763,33 +840,38 @@ def _scan_audio_streams(src: str) -> tuple[str, str]:
 
 
 def _detect(path: str) -> dict[str, str]:
-    """Return compact Dolby Vision + audio metadata for the given playing path."""
-    src, is_temp = _local_source(path)
-    try:
-        info = {}
-        probe = _hdrprobe()
-        if not probe or not os.path.exists(probe):
-            _log(f"DV: hdrprobe binary missing ({probe})", xbmc.LOGWARNING)
-        else:
-            data = _run_hdrprobe(probe, src)
-            if data is not None:
-                info = _parse_probe(data)
+    """Return compact Dolby Vision + audio metadata for the given playing path.
 
-        # The audio bitstream scan reads the same local chunk, so it runs
-        # even when hdrprobe itself is unavailable or failed.
-        audio_depths, audio_rates = _scan_audio_streams(src)
-        if audio_depths or audio_rates:
-            if not info:
-                info = _empty_info()
-            info["audio_depths"] = audio_depths
-            info["audio_rates"] = audio_rates
-        return info
-    finally:
-        if is_temp and os.path.exists(_CHUNK_PATH):
-            try:
-                os.remove(_CHUNK_PATH)
-            except OSError:
-                pass
+    Real filesystem paths are probed by hdrprobe directly (fullest analysis);
+    Kodi VFS URLs — which hdrprobe cannot open — are streamed into it over
+    stdin, so nothing is copied to a temporary chunk file.  The audio bitstream
+    scan reuses the same head bytes and runs even when hdrprobe is unavailable.
+    """
+    source = _resolve_disc_stream(path)
+    is_local = source.startswith("/")
+
+    probe = _hdrprobe()
+    have_probe = bool(probe) and os.path.exists(probe)
+    if not have_probe:
+        _log(f"DV: hdrprobe binary missing ({probe})", xbmc.LOGWARNING)
+
+    if is_local:
+        data = _run_hdrprobe(probe, source) if have_probe else None
+        head = _read_local_head(source)
+    elif have_probe:
+        data, head = _probe_stream_stdin(probe, source)
+    else:
+        data, head = None, _read_vfs_head(source)
+
+    info = _parse_probe(data) if data is not None else {}
+
+    audio_depths, audio_rates = _audio_fields(head)
+    if audio_depths or audio_rates:
+        if not info:
+            info = _empty_info()
+        info["audio_depths"] = audio_depths
+        info["audio_rates"] = audio_rates
+    return info
 
 
 def _worker(path: str, session_token: str) -> None:

--- a/resources/lib/dvinfo.py
+++ b/resources/lib/dvinfo.py
@@ -34,18 +34,23 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcvfs
-from audioprobe import scan_audio_streams
+from audioprobe import AudioStreamScanner
 
 _ADDON      = xbmcaddon.Addon()
 
-# Blocks piped into hdrprobe's stdin.  hdrprobe decides how much to read (a
-# format-specific head budget), so this is only the VFS read granularity.
+# Read granularity for the VFS/file stream.  hdrprobe decides how much to read
+# itself (a format-specific head budget), so on the stdin path this is only the
+# block size; the audio scanner consumes the same blocks incrementally, holding
+# just one block at a time rather than a fixed head buffer.
 _BLOCK_BYTES = 1024 * 1024
 
-# Head window captured for the audio bitstream scan.  16 MiB holds the first
-# GOP (keyframe + RPU) even at UHD Blu-ray bitrates and sits within hdrprobe's
-# own head budget, so the VFS stream is still read only once.
-_HEAD_BYTES   = 16 * 1024 * 1024
+# How far the audio scan reads when hdrprobe is *not* bounding the read — i.e.
+# for real local files (hdrprobe reads those to EOF on its own) and the rare
+# fallback where hdrprobe is unavailable.  On the stdin path there is no such
+# limit: the scan is bounded by hdrprobe's own budget.  It caps the read
+# distance only; memory stays at one block regardless of this value.  Audio
+# frames are interleaved near the start, well within this window.
+_AUDIO_SCAN_LIMIT = 16 * 1024 * 1024
 
 _LABEL_FETCH = 32096
 _LABEL_NA    = 32033
@@ -356,32 +361,47 @@ def _resolve_disc_stream(path: str) -> str:
     return path
 
 
-def _read_vfs_head(vfs_url: str) -> bytes:
-    """Return the first ``_HEAD_BYTES`` of a Kodi VFS stream for the audio scan.
-
-    Only used when hdrprobe itself is unavailable; otherwise the head window is
-    captured for free while the stream is piped into the probe (see
-    ``_probe_stream_stdin``), so the stream is never read twice."""
+def _scan_audio_vfs(vfs_url: str) -> dict[str, dict[str, int]]:
+    """Scan a Kodi VFS stream for audio bitstreams, reading it in blocks up to
+    ``_AUDIO_SCAN_LIMIT`` and feeding them straight into the incremental scanner
+    (no head buffer).  Only used when hdrprobe is unavailable; otherwise the same
+    blocks are scanned for free while streaming into the probe."""
+    scanner = AudioStreamScanner()
     try:
         f = xbmcvfs.File(vfs_url)
         try:
-            return bytes(f.readBytes(_HEAD_BYTES))
+            read = 0
+            while read < _AUDIO_SCAN_LIMIT:
+                block = f.readBytes(_BLOCK_BYTES)
+                if not block:
+                    break
+                read += len(block)
+                scanner.feed(block)
         finally:
             f.close()
     except Exception as exc:
-        _log(f"Audio: VFS head read failed for {vfs_url}: {exc}", xbmc.LOGWARNING)
-        return b""
+        _log(f"Audio: VFS scan failed for {vfs_url}: {exc}", xbmc.LOGWARNING)
+    scanner.finish()
+    return scanner.result()
 
 
-def _read_local_head(path: str) -> bytes:
-    """Return the first ``_HEAD_BYTES`` of a real filesystem ``path`` for the
-    audio scan, or ``b""`` when it can't be read."""
+def _scan_audio_local(path: str) -> dict[str, dict[str, int]]:
+    """Scan a real filesystem ``path`` for audio bitstreams, reading it in blocks
+    up to ``_AUDIO_SCAN_LIMIT`` and feeding the incremental scanner."""
+    scanner = AudioStreamScanner()
     try:
         with open(path, "rb") as f:
-            return f.read(_HEAD_BYTES)
+            read = 0
+            while read < _AUDIO_SCAN_LIMIT:
+                block = f.read(_BLOCK_BYTES)
+                if not block:
+                    break
+                read += len(block)
+                scanner.feed(block)
     except OSError as exc:
-        _log(f"Audio: head read failed: {exc}", xbmc.LOGWARNING)
-        return b""
+        _log(f"Audio: scan failed: {exc}", xbmc.LOGWARNING)
+    scanner.finish()
+    return scanner.result()
 
 
 def _compact_cm_version(value: str) -> str:
@@ -760,18 +780,22 @@ def _run_hdrprobe(probe: str, src: str) -> dict | None:
     return _decode_report(out)
 
 
-def _probe_stream_stdin(probe: str, vfs_url: str) -> tuple[dict | None, bytes]:
+def _probe_stream_stdin(
+    probe: str, vfs_url: str
+) -> tuple[dict | None, dict[str, dict[str, int]]]:
     """Probe a Kodi VFS stream without copying it to disk.
 
     hdrprobe cannot open nfs:// / smb:// / bluray:// / udf:// / https:// URLs
     itself, so the stream is piped into ``hdrprobe --json -``: blocks are read
     through xbmcvfs and written to its stdin until hdrprobe has taken its head
     budget (the write then fails with a broken pipe — the documented success
-    signal) or the stream ends within budget.  The first ``_HEAD_BYTES`` are
-    captured along the way for the audio scan, so the stream is read only once.
+    signal) or the stream ends within budget.  Each block is also fed to the
+    incremental audio scanner as it goes by, so the stream is read only once and
+    nothing larger than a single block is ever held in memory.
 
-    Returns ``(report, head_bytes)``; ``report`` is ``None`` when hdrprobe
-    emitted no decodable JSON.
+    Returns ``(report, audio_streams)``; ``report`` is ``None`` when hdrprobe
+    emitted no decodable JSON, ``audio_streams`` is the scanner's per-family
+    result (see ``AudioStreamScanner.result``).
     """
     try:
         proc = subprocess.Popen(
@@ -782,9 +806,9 @@ def _probe_stream_stdin(probe: str, vfs_url: str) -> tuple[dict | None, bytes]:
         )
     except OSError as exc:
         _log(f"DV: hdrprobe failed to start: {exc}", xbmc.LOGWARNING)
-        return None, _read_vfs_head(vfs_url)
+        return None, _scan_audio_vfs(vfs_url)
 
-    head = bytearray()
+    scanner = AudioStreamScanner()
     try:
         f = xbmcvfs.File(vfs_url)
         try:
@@ -792,8 +816,7 @@ def _probe_stream_stdin(probe: str, vfs_url: str) -> tuple[dict | None, bytes]:
                 block = f.readBytes(_BLOCK_BYTES)
                 if not block:
                     break  # end of stream within hdrprobe's budget
-                if len(head) < _HEAD_BYTES:
-                    head.extend(block[: _HEAD_BYTES - len(head)])
+                scanner.feed(block)
                 try:
                     proc.stdin.write(block)
                 except (BrokenPipeError, OSError):
@@ -802,6 +825,7 @@ def _probe_stream_stdin(probe: str, vfs_url: str) -> tuple[dict | None, bytes]:
             f.close()
     except Exception as exc:
         _log(f"DV: VFS read failed for {vfs_url}: {exc}", xbmc.LOGWARNING)
+    scanner.finish()
 
     # communicate() closes stdin (signalling EOF for short streams) and drains
     # the small JSON report; hdrprobe writes it only after it stops reading, so
@@ -812,20 +836,15 @@ def _probe_stream_stdin(probe: str, vfs_url: str) -> tuple[dict | None, bytes]:
         _log(f"DV: hdrprobe did not complete: {exc}", xbmc.LOGWARNING)
         proc.kill()
         proc.communicate()
-        return None, bytes(head)
+        return None, scanner.result()
 
     report = _decode_report(out.decode("utf-8", "replace")) if out else None
-    return report, bytes(head)
+    return report, scanner.result()
 
 
-def _audio_fields(head: bytes) -> tuple[str, str]:
-    """Scan the stream ``head`` for audio bitstreams and serialize the detected
-    source metrics as a ``(depths, rates)`` pair of per-family strings, e.g.
-    ``("dts=24;truehd=24", "dts=96000")`` ('' when none)."""
-    if not head:
-        return "", ""
-
-    streams = scan_audio_streams(head)
+def _audio_fields(streams: dict[str, dict[str, int]]) -> tuple[str, str]:
+    """Serialize the scanner's per-family metrics as a ``(depths, rates)`` pair
+    of strings, e.g. ``("dts=24;truehd=24", "dts=96000")`` ('' when none)."""
     depths = ";".join(
         f"{family}={fields['depth']}"
         for family, fields in sorted(streams.items())
@@ -845,7 +864,8 @@ def _detect(path: str) -> dict[str, str]:
     Real filesystem paths are probed by hdrprobe directly (fullest analysis);
     Kodi VFS URLs — which hdrprobe cannot open — are streamed into it over
     stdin, so nothing is copied to a temporary chunk file.  The audio bitstream
-    scan reuses the same head bytes and runs even when hdrprobe is unavailable.
+    scan consumes the same blocks incrementally and runs even when hdrprobe is
+    unavailable.
     """
     source = _resolve_disc_stream(path)
     is_local = source.startswith("/")
@@ -857,15 +877,15 @@ def _detect(path: str) -> dict[str, str]:
 
     if is_local:
         data = _run_hdrprobe(probe, source) if have_probe else None
-        head = _read_local_head(source)
+        streams = _scan_audio_local(source)
     elif have_probe:
-        data, head = _probe_stream_stdin(probe, source)
+        data, streams = _probe_stream_stdin(probe, source)
     else:
-        data, head = None, _read_vfs_head(source)
+        data, streams = None, _scan_audio_vfs(source)
 
     info = _parse_probe(data) if data is not None else {}
 
-    audio_depths, audio_rates = _audio_fields(head)
+    audio_depths, audio_rates = _audio_fields(streams)
     if audio_depths or audio_rates:
         if not info:
             info = _empty_info()

--- a/resources/lib/dvinfo.py
+++ b/resources/lib/dvinfo.py
@@ -57,6 +57,14 @@ _BLOCK_BYTES = 1024 * 1024
 # This caps the read distance only — peak memory stays at one block.
 _AUDIO_SCAN_LIMIT = 4 * 1024 * 1024
 
+# Upper bound on how long to wait for hdrprobe to finish.  Detection runs in a
+# daemon background thread, so a probe that never exits (a broken build, a stuck
+# signal) would otherwise hang that thread forever and leave the overlay on
+# "Fetching...".  hdrprobe 0.6.0 keeps a sub-2s guarantee without --full, so
+# this only ever trips on a genuine hang; on timeout the probe is killed and the
+# result falls back to N/A, exactly like any other failed detection.
+_PROBE_TIMEOUT = 30
+
 _LABEL_FETCH = 32096
 _LABEL_NA    = 32033
 
@@ -526,11 +534,21 @@ def _static_hdr_token(
     The ``format`` label is unreliable for HDR10 (its SEI is not in every
     chunk), so the transfer characteristic and mastering-display block are
     checked first; the format label is only a last resort.
+
+    hdrprobe's schema 2.x nests the transfer characteristic in a ``color``
+    block (``color.transfer``); 1.x kept it on the track/``hdr`` block.  All
+    three spots are consulted so the read location does not matter.
     """
     if hdr10plus:
         return "hdr10+"
 
-    transfer = (hdr.get("transfer") or general.get("transfer") or "").lower()
+    color = general.get("color") or {}
+    transfer = (
+        hdr.get("transfer")
+        or color.get("transfer")
+        or general.get("transfer")
+        or ""
+    ).lower()
     if "hlg" in transfer or "b67" in transfer:
         return "hlg"
     if "pq" in transfer or "2084" in transfer or hdr.get("mastering"):
@@ -777,9 +795,12 @@ def _run_hdrprobe(probe: str, src: str) -> dict | None:
             # UnicodeDecodeError.  errors="replace" tolerates stray bytes too.
             encoding="utf-8",
             errors="replace",
+            # Guard the background thread against a probe that never exits;
+            # subprocess.run kills it on timeout (raises TimeoutExpired).
+            timeout=_PROBE_TIMEOUT,
         ).stdout
-    except OSError as exc:
-        _log(f"DV: hdrprobe failed to start: {exc}", xbmc.LOGWARNING)
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log(f"DV: hdrprobe did not complete: {exc}", xbmc.LOGWARNING)
         return None
 
     return _decode_report(out)
@@ -834,9 +855,10 @@ def _probe_stream_stdin(
 
     # communicate() closes stdin (signalling EOF for short streams) and drains
     # the small JSON report; hdrprobe writes it only after it stops reading, so
-    # there is no deadlock.
+    # there is no deadlock.  The timeout guards the background thread against a
+    # probe that never exits (TimeoutExpired is caught below, killed and reaped).
     try:
-        out, _ = proc.communicate()
+        out, _ = proc.communicate(timeout=_PROBE_TIMEOUT)
     except Exception as exc:
         _log(f"DV: hdrprobe did not complete: {exc}", xbmc.LOGWARNING)
         proc.kill()


### PR DESCRIPTION
Stream media into hdrprobe over stdin, without temp chunk files

Use hdrprobe's stdin integration (`hdrprobe --json -`) so Kodi VFS streams
(nfs/smb/http(s)/ftp/sftp/dav/udf/bluray/stack/…) are piped straight into the
probe instead of being copied into a special://temp chunk file. Real local
files still go to hdrprobe directly for full-file analysis.

- Audio detection becomes an incremental scanner fed the same blocks; it holds
  only one block plus an 8 KiB overlap instead of a fixed 16 MiB head buffer,
  with the majority-vote result byte-for-byte identical to a one-shot scan.
- The audio read distance is bounded at 4 MiB only where hdrprobe is not driving
  the read (local files / no-binary fallback); the stdin path is bounded by
  hdrprobe itself.
- Classify HDR from the schema-2.x color.transfer block, and time-box both probe
  spawns so a stuck probe can never hang the background detection thread.

Net effect: no temp-file writes, transient memory ~32 MiB -> ~1 MiB, overlay
output unchanged. Verified end to end against the real hdrprobe pre-release.