### PR TITLE
Clean up dead code and orphaned strings

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -63,10 +63,6 @@ msgctxt "#32019"
 msgid "Show file name"
 msgstr "Dateiname anzeigen"
 
-msgctxt "#32020"
-msgid "Style"
-msgstr "Stil"
-
 msgctxt "#32021"
 msgid "Show the currently playing file name in TinyPPI."
 msgstr "Zeigt den Dateinamen der aktuellen Wiedergabe in TinyPPI an."
@@ -191,17 +187,9 @@ msgctxt "#32096"
 msgid "Fetching..."
 msgstr "Wird ermittelt..."
 
-msgctxt "#32098"
-msgid "L6 MaxCLL/FALL"
-msgstr "L6 MaxCLL/FALL"
-
 msgctxt "#32099"
 msgid "Bit depth"
 msgstr "Bittiefe"
-
-msgctxt "#32100"
-msgid "Theme"
-msgstr "Design"
 
 msgctxt "#32101"
 msgid "Customise the TinyPPI overlay colors."
@@ -747,10 +735,6 @@ msgctxt "#32245"
 msgid "Custom color applied"
 msgstr "Benutzerdefinierte Farbe übernommen"
 
-msgctxt "#32246"
-msgid "Color selection"
-msgstr "Farbauswahl"
-
 msgctxt "#32250"
 msgid "Custom"
 msgstr "Benutzerdefiniert"
@@ -826,14 +810,6 @@ msgstr "Globaler Hintergrund"
 msgctxt "#32271"
 msgid "Color of the full-screen global background."
 msgstr "Farbe des bildschirmfüllenden globalen Hintergrunds."
-
-msgctxt "#32272"
-msgid "Mastering Display"
-msgstr "Mastering Display"
-
-msgctxt "#32273"
-msgid "MaxCLL/FALL"
-msgstr "MaxCLL/FALL"
 
 msgctxt "#32274"
 msgid "Opacity of this element, from 0% (fully transparent) to 100% (fully opaque)."
@@ -983,14 +959,6 @@ msgctxt "#32310"
 msgid "Codec logos shown on the picture when playback starts or the OSD is open."
 msgstr "Codec-Logos, die beim Wiedergabestart oder bei geöffneter OSD im Bild angezeigt werden."
 
-msgctxt "#32311"
-msgid "Background behind the logos"
-msgstr "Hintergrund hinter den Logos"
-
-msgctxt "#32312"
-msgid "Draws a translucent panel behind the logos so they stay readable on bright scenes."
-msgstr "Zeichnet eine transparente Fläche hinter den Logos, damit sie auch bei hellen Szenen gut erkennbar bleiben."
-
 msgctxt "#32313"
 msgid "Background color"
 msgstr "Hintergrundfarbe"
@@ -1094,14 +1062,6 @@ msgstr "Automatisch ausblenden"
 msgctxt "#32345"
 msgid "Automatically hides the TinyPPI overlay after the selected time (in seconds). 0 = off. Does not apply to the VS10 dialog."
 msgstr "Blendet das TinyPPI-Overlay nach der eingestellten Zeit (in Sekunden) automatisch aus. 0 = Aus. Gilt nicht für den VS10-Dialog."
-
-msgctxt "#32346"
-msgid "Show channel layout graphic"
-msgstr "Kanal-Layout-Grafik anzeigen"
-
-msgctxt "#32347"
-msgid "Show a speaker layout graphic for the active audio track above the chart icon."
-msgstr "Zeigt über dem Chart-Symbol eine Lautsprecher-Layout-Grafik für die aktive Tonspur an."
 
 msgctxt "#32348"
 msgid "Horizontal offset of the channel box"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -63,10 +63,6 @@ msgctxt "#32019"
 msgid "Show file name"
 msgstr ""
 
-msgctxt "#32020"
-msgid "Style"
-msgstr ""
-
 msgctxt "#32021"
 msgid "Show the currently playing file name in TinyPPI."
 msgstr ""
@@ -191,16 +187,8 @@ msgctxt "#32096"
 msgid "Fetching..."
 msgstr ""
 
-msgctxt "#32098"
-msgid "L6 MaxCLL/FALL"
-msgstr ""
-
 msgctxt "#32099"
 msgid "Bit depth"
-msgstr ""
-
-msgctxt "#32100"
-msgid "Theme"
 msgstr ""
 
 msgctxt "#32101"
@@ -747,10 +735,6 @@ msgctxt "#32245"
 msgid "Custom color applied"
 msgstr ""
 
-msgctxt "#32246"
-msgid "Color selection"
-msgstr ""
-
 msgctxt "#32250"
 msgid "Custom"
 msgstr ""
@@ -825,14 +809,6 @@ msgstr ""
 
 msgctxt "#32271"
 msgid "Color of the full-screen global background."
-msgstr ""
-
-msgctxt "#32272"
-msgid "Mastering Display"
-msgstr ""
-
-msgctxt "#32273"
-msgid "MaxCLL/FALL"
 msgstr ""
 
 msgctxt "#32274"
@@ -983,14 +959,6 @@ msgctxt "#32310"
 msgid "Codec logos shown on the picture when playback starts or the OSD is open."
 msgstr ""
 
-msgctxt "#32311"
-msgid "Background behind the logos"
-msgstr ""
-
-msgctxt "#32312"
-msgid "Draws a translucent panel behind the logos so they stay readable on bright scenes."
-msgstr ""
-
 msgctxt "#32313"
 msgid "Background color"
 msgstr ""
@@ -1093,14 +1061,6 @@ msgstr ""
 
 msgctxt "#32345"
 msgid "Automatically hides the TinyPPI overlay after the selected time (in seconds). 0 = off. Does not apply to the VS10 dialog."
-msgstr ""
-
-msgctxt "#32346"
-msgid "Show channel layout graphic"
-msgstr ""
-
-msgctxt "#32347"
-msgid "Show a speaker layout graphic for the active audio track above the chart icon."
 msgstr ""
 
 msgctxt "#32348"

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -63,10 +63,6 @@ msgctxt "#32019"
 msgid "Show file name"
 msgstr "显示文件名"
 
-msgctxt "#32020"
-msgid "Style"
-msgstr "样式"
-
 msgctxt "#32021"
 msgid "Show the currently playing file name in TinyPPI."
 msgstr "在 TinyPPI 中显示当前播放文件的名称。"
@@ -191,17 +187,9 @@ msgctxt "#32096"
 msgid "Fetching..."
 msgstr "正在获取..."
 
-msgctxt "#32098"
-msgid "L6 MaxCLL/FALL"
-msgstr "L6 MaxCLL/FALL"
-
 msgctxt "#32099"
 msgid "Bit depth"
 msgstr "位深度"
-
-msgctxt "#32100"
-msgid "Theme"
-msgstr "主题"
 
 msgctxt "#32101"
 msgid "Customise the TinyPPI overlay colors."
@@ -747,10 +735,6 @@ msgctxt "#32245"
 msgid "Custom color applied"
 msgstr "已应用自定义颜色"
 
-msgctxt "#32246"
-msgid "Color selection"
-msgstr "颜色选择"
-
 msgctxt "#32250"
 msgid "Custom"
 msgstr "自定义"
@@ -826,14 +810,6 @@ msgstr "全局背景"
 msgctxt "#32271"
 msgid "Color of the full-screen global background."
 msgstr "全屏全局背景的颜色。"
-
-msgctxt "#32272"
-msgid "Mastering Display"
-msgstr "母版显示"
-
-msgctxt "#32273"
-msgid "MaxCLL/FALL"
-msgstr "MaxCLL/FALL"
 
 msgctxt "#32274"
 msgid "Opacity of this element, from 0% (fully transparent) to 100% (fully opaque)."
@@ -983,14 +959,6 @@ msgctxt "#32310"
 msgid "Codec logos shown on the picture when playback starts or the OSD is open."
 msgstr "在播放开始或 OSD 打开时显示在画面上的编解码器徽标。"
 
-msgctxt "#32311"
-msgid "Background behind the logos"
-msgstr "徽标后的背景"
-
-msgctxt "#32312"
-msgid "Draws a translucent panel behind the logos so they stay readable on bright scenes."
-msgstr "在徽标后方绘制一块半透明面板，使其在明亮场景中仍清晰可见。"
-
 msgctxt "#32313"
 msgid "Background color"
 msgstr "背景颜色"
@@ -1094,14 +1062,6 @@ msgstr "自动隐藏"
 msgctxt "#32345"
 msgid "Automatically hides the TinyPPI overlay after the selected time (in seconds). 0 = off. Does not apply to the VS10 dialog."
 msgstr "在设定的时间（秒）后自动隐藏 TinyPPI 叠加层。0 = 关闭。不适用于 VS10 对话框。"
-
-msgctxt "#32346"
-msgid "Show channel layout graphic"
-msgstr "显示声道布局图"
-
-msgctxt "#32347"
-msgid "Show a speaker layout graphic for the active audio track above the chart icon."
-msgstr "在图表图标上方显示当前音轨的扬声器布局图。"
 
 msgctxt "#32348"
 msgid "Horizontal offset of the channel box"

--- a/resources/lib/ui/overlay.py
+++ b/resources/lib/ui/overlay.py
@@ -19,7 +19,7 @@ from core.utils import (
     set_window_properties,
 )
 from info import properties
-from ui import fonts
+from ui import fonts  # noqa: F401  imported for its install-fonts-on-import side effect
 from ui.theme import apply_theme
 
 # ---------------------------------------------------------------------------

--- a/resources/lib/ui/splash.py
+++ b/resources/lib/ui/splash.py
@@ -15,7 +15,6 @@ audio-track change follows live.
 """
 
 import os
-import struct
 import time
 
 import xbmc


### PR DESCRIPTION
- Remove unused `import struct` in ui/splash.py.
- Annotate the side-effect-only `from ui import fonts` in ui/overlay.py (installs fonts on import) so it reads intentionally and is not stripped as unused.
- Drop 10 orphaned localization strings that no code or skin/settings XML references any more (superseded or never wired up): 32020, 32098, 32100, 32246, 32272, 32273, 32311, 32312, 32346, 32347 — removed consistently from de_de, en_gb and zh_cn.