### PR TITLE
Fix empty widened overlay when channels enabled but no audio channels

### DIFF
--- a/resources/skins/Default/1080i/script-tinyppi-main.xml
+++ b/resources/skins/Default/1080i/script-tinyppi-main.xml
@@ -21,7 +21,7 @@
         <control type="group" id="5000">
 			<!-- Overlay - SDR - w/o Channels -->
 			<control type="group">
-			<visible>String.IsEqual(Window(10000).Property(TinyPPI.ShowChannelIcon),0)</visible>
+			<visible>String.IsEqual(Window(10000).Property(TinyPPI.ShowChannelIcon),0) | String.IsEmpty(Window().Property(ChannelIconVar))</visible>
 			<visible>String.IsEmpty(Window(10000).Property(TinyPPI.HdrType))</visible>
 
 				<!-- Background - Start -->
@@ -1399,9 +1399,9 @@
 					</control>
 					
 					<control type="group">
-						<visible>String.IsEqual(Window(10000).Property(TinyPPI.ShowChannelIcon),0)</visible>
+						<visible>String.IsEqual(Window(10000).Property(TinyPPI.ShowChannelIcon),0) | String.IsEmpty(Window().Property(ChannelIconVar))</visible>
 						<top>207</top>
-						
+
 						<!-- HDR Static Metadata Icon -->
 						<control type="image">
 							<top>4</top>


### PR DESCRIPTION
When the channel-icon setting is enabled (ShowChannelIcon=1) but the played content exposes no mappable audio channels, ChannelIconVar is empty. The skin's 'with channels' branches require a non-empty ChannelIconVar while the 'without channels' fallbacks only matched ShowChannelIcon=0, so neither branch rendered: the HDR box stayed widened with an empty metadata column, and the SDR box vanished entirely.

Let the fallback branches also fire when ChannelIconVar is empty, so the overlay falls back to its no-channels layout for both SDR and HDR.