### PR TITLE
Read the base-layer mastering display under its schema 3.0 name

### DIFF
--- a/resources/lib/info/dvinfo.py
+++ b/resources/lib/info/dvinfo.py
@@ -562,6 +562,18 @@ def _sl_hdr_label(sl_hdr: dict) -> str:
     return ""
 
 
+def _static_mastering(hdr: dict) -> dict:
+    """Return the base layer's mastering-display block from the ``hdr`` block.
+
+    Schema 3.0 renamed ``hdr.mastering`` to ``hdr.mastering_display`` (one name
+    for the shape shared with the Dolby Vision and SL-HDR blocks).  Both names
+    are read, newest first, so a report from either schema resolves — the
+    bundled on-device hdrprobe may still be a 2.x build.
+    """
+    mastering = hdr.get("mastering_display") or hdr.get("mastering")
+    return mastering if isinstance(mastering, dict) else {}
+
+
 def _static_hdr_token(
     general: dict, hdr: dict, hdr10plus: dict, raw_format: str
 ) -> str:
@@ -587,7 +599,7 @@ def _static_hdr_token(
     ).lower()
     if "hlg" in transfer or "b67" in transfer:
         return "hlg"
-    if "pq" in transfer or "2084" in transfer or hdr.get("mastering"):
+    if "pq" in transfer or "2084" in transfer or _static_mastering(hdr):
         return "hdr10"
 
     return _hdr_type_token(raw_format)
@@ -800,14 +812,14 @@ def _parse_probe(data: dict) -> dict[str, str]:
         content_light = dovi.get("l6") or {}
     else:
         # HDR10 and other static-HDR formats carry them as static metadata.
-        mdl = hdr.get("mastering") or {}
+        mdl = _static_mastering(hdr)
         content_light = hdr.get("content_light") or {}
 
     # The ``l6_*`` rows come from the source selected above; the ``hdr10_*``
     # rows always come from the static ``hdr`` block, so a DV stream shows its
     # HDR10 fallback layer distinctly from the RPU (L6) values.  Missing values
     # are left blank (rendered as ``0 | 0`` by the luminance getters).
-    static_mdl = hdr.get("mastering") or {}
+    static_mdl = _static_mastering(hdr)
     static_light = hdr.get("content_light") or {}
     for key, source, key_a, key_b in (
         ("l6_mdl", mdl, "max_luminance", "min_luminance"),


### PR DESCRIPTION
hdrprobe 1.0.0 (released today) reports under JSON schema 3.0, which renamed `hdr.mastering` to `hdr.mastering_display`. On a 3.0 report the old lookup returns nothing, so the HDR10 MDL row goes blank on every HDR10 title and on the base-layer row of every Dolby Vision title, while the RPU L6 row (read from the `dolby_vision` block) keeps working.

This adds a `_static_mastering()` helper that reads the new name first and falls back to the old one, so the addon works unchanged whether the bundled hdrprobe is a current 2.x build or the 1.0.0 release — an in-place binary upgrade needs no addon change, and an older binary keeps working.

Verified against the actual v1.0.0 release binary over a 21-file corpus covering DV profiles 4/5/7 (FEL and MEL)/8.1/8.4/9/10/20 plus HDR10, HDR10+, HLG, SL-HDR2, HDR Vivid and SDR, on both the direct-path and `--json -` stdin invocations (head budgets unchanged: 24 MiB for M2TS/TS, 16 MiB otherwise). The legacy schema-2.x report shape was verified to parse identically through the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)