### PR TITLE
Poll Dolby Vision metadata at 100ms with cheap idle ticks

### DIFF
--- a/resources/lib/core/utils.py
+++ b/resources/lib/core/utils.py
@@ -165,6 +165,21 @@ def set_window_properties(window, values: tuple[tuple[str, str], ...]) -> None:
         window.setProperty(name, value)
 
 
+def set_changed_properties(window, published: dict, values: tuple[tuple[str, str], ...]) -> None:
+    """Publish only the values that differ from what ``published`` last recorded.
+
+    ``published`` is the caller's own tracking dict, kept for the life of
+    whatever polls this window; only the entries actually written here are
+    updated in it, so it stays an accurate record of what the window holds
+    even when something else (a highlight overwrite, say) also writes to the
+    same keys and updates the same dict.
+    """
+    for name, value in values:
+        if published.get(name) != value:
+            window.setProperty(name, value)
+            published[name] = value
+
+
 def clear_overlay_state(home) -> None:
     """Clear the Home-window properties that mark TinyPPI as open."""
     for prop in (PROP_RUNNING, PROP_ACTIVE, PROP_DIALOG_MODE):

--- a/resources/lib/info/dvmetadata.py
+++ b/resources/lib/info/dvmetadata.py
@@ -673,26 +673,25 @@ def _state(origin: dict, *keys: str) -> str:
 
 # --- Row model -------------------------------------------------------------
 
-def build_rows(parsed: dict | None = None) -> list[tuple[str, str, str]]:
-    """Return the metadata view's rows for the frame on screen.
+def build_scene_rows(
+    parsed: dict | None = None,
+) -> tuple[list[tuple[str, str, str]], dict, dict, str]:
+    """Return the rows that can change every scene, plus the held-filled
+    parse result, its origin map and its payload summary for
+    ``build_static_rows`` to render the rest of the view from the same
+    frame's data without re-deriving any of it.
 
-    Reads the current side data unless a parse result is passed in.  Every
-    section is laid out in the same order every time, but only the readings the
-    stream carries survive it: a block this stream has no data for takes no
-    room, so what is on screen is what the bitstream said and the sections that
-    are there can be read without hunting between empty ones.
+    Reads the current side data unless a parse result is passed in.  L1 says
+    how bright the frame is, L2 and L8 say what was done about it, L5 and L3
+    describe the active area and its PQ offsets, and HDR10+'s dynamic
+    metadata is scene by scene too -- these are the readings a viewer is
+    watching move, so unlike the rest of the view (see build_static_rows)
+    they need re-reading on every poll rather than settling for a slower one.
 
-    Ordered by what moves rather than by the numbers the levels carry: the
-    per-frame blocks first, then the ones that describe the grade, then what
-    the file is.  A list this long is read from the top, and the top is worth
-    the readings that are different every time it is looked at -- the levels
-    still run in order within the first group, save for L8 kept beside L2,
-    which is the other half of the same answer.
-
-    Read live, the blocks a compressed frame omits are held from the last frame
-    that carried them and their heading says so (see _hold).  A parse result
-    passed in is taken as it comes and holds nothing, so a caller with its own
-    data gets its own data, every section of it live.
+    Read live, the blocks a compressed frame omits are held from the last
+    frame that carried them and their heading says so (see _hold).  A parse
+    result passed in is taken as it comes and holds nothing, so a caller with
+    its own data gets its own data, every section of it live.
     """
     live   = parsed is None
     parsed = get_sidedata() if live else parsed
@@ -727,6 +726,35 @@ def build_rows(parsed: dict | None = None) -> list[tuple[str, str, str]]:
         _section(rows, "HDR10+ (ST 2094-40)", _hdr10plus_pairs(hdr10plus),
                  _state(origin, "hdr10plus"))
 
+    return rows, parsed, origin, carried
+
+
+def build_static_rows(parsed: dict, origin: dict, carried: str) -> list[tuple[str, str, str]]:
+    """Return the rows that settle before the film was ever played, from a
+    parse result, origin map and payload summary ``build_scene_rows`` already
+    produced for the same frame.
+
+    The source range, L6, L9, L10, L11, the static SEIs, the RPU header and
+    the file-level blocks are all the same on every frame of a title, so
+    unlike build_scene_rows's readings a caller may re-render these on a
+    slower cadence -- their Live/Cached heading badge (see _state) reflects
+    whichever frame's origin map it was called with, not necessarily the one
+    on screen right now, which is the one place that trades off freshness for
+    the slower poll.
+
+    Returned without the blank row that would separate it from whatever
+    precedes it: a caller re-rendering this on its own slower cadence and
+    joining it against a scene list that is fresh every call (see
+    join_rows) needs that decided against the *current* scene rows, not
+    baked in here against whichever tick last rebuilt this list -- the two
+    can disagree on whether scene rows exist at all around the moment
+    detection resolves, and a blank row baked in against the wrong tick
+    would leave the joined list either missing its separator or opening on
+    an orphan one until this next re-renders.
+    """
+    rpu = parsed.get("rpu")
+    rows: list[tuple[str, str, str]] = []
+
     # Then the grade: settled before the film was ever played, and the same on
     # every frame of it.  The source range is here rather than above because
     # it describes the master, however per-frame the RPU carrying it is.
@@ -754,6 +782,97 @@ def build_rows(parsed: dict | None = None) -> list[tuple[str, str, str]]:
     _section(rows, "Configuration record (dvcC / dvvC)",
              _config_pairs(parsed.get("config")), _state(origin, "config"))
     _section(rows, "Stream", _stream_pairs(parsed, carried))
+
+    return rows
+
+
+# The keys build_static_rows judges its headings' Live / Cached state by.
+_STATIC_STATE_KEYS = ("rpu.source", "rpu.l6", "rpu.l9", "rpu.l10", "rpu.l11",
+                      "mdcv", "cll", "rpu", "rpu.header", "config")
+
+
+def static_signature(parsed: dict, origin: dict, carried: str) -> tuple:
+    """What build_static_rows's rows are made from, as one comparable value.
+
+    A caller re-rendering those rows on a slower cadence than the scene rows
+    (see ui.dvmetadata's _merged_rows) can compare this against the last
+    tick's and re-render the moment a static block actually moves -- a DM
+    refresh that replaces the source range or a target display mid-title --
+    instead of up to a whole interval after it, which is the lag that reads
+    as rows changing out of step with the scene sections above them.  A tick
+    nothing moved in costs one tuple comparison and no formatting.
+
+    Almost everything build_static_rows reads from its three arguments is in
+    here, the heading states included.  Left out on purpose: the Stream
+    section's own live reads outside them (the Kodi labels and the parser
+    module version, see _stream_pairs), and the three scalars _rpu_pairs
+    reads straight off the RPU -- profile, cm_version, compressed.  Those are
+    the frame's own, not held (see _HELD_RPU), and compressed above all is
+    genuinely per-frame: it flips with DM compression's key/compressed
+    cadence, so carrying it here would rebuild on every such flip and defeat
+    the throttle this signature exists to protect.  Their rows ride the
+    caller's slower fallback interval instead, as they always did.
+    """
+    rpu = parsed.get("rpu") or {}
+    return (
+        carried,
+        parsed.get("flags"),
+        parsed.get("structure"),
+        parsed.get("config"),
+        parsed.get("mdcv"),
+        parsed.get("cll"),
+        rpu.get("header"),
+        rpu.get("source"),
+        rpu.get("l6"),
+        rpu.get("l9"),
+        rpu.get("l10"),
+        rpu.get("l11"),
+        tuple(origin.get(key) for key in _STATIC_STATE_KEYS),
+    )
+
+
+def join_rows(
+    scene_rows: list[tuple[str, str, str]], static_rows: list[tuple[str, str, str]],
+) -> list[tuple[str, str, str]]:
+    """Concatenate build_scene_rows's and build_static_rows's output, adding
+    back the blank row _section would have put ahead of the first static
+    heading if it had built straight into the scene rows rather than its own
+    fresh list.
+
+    Takes both lists as given rather than a ``preceded`` flag decided ahead
+    of time, so a caller re-rendering the two halves on different cadences
+    (see ui.dvmetadata's _merged_rows) gets this decided fresh against
+    whichever scene rows it is joining right now, not against whichever
+    tick's scene rows happened to be current when static_rows was last
+    rebuilt -- those can disagree for as long as the static side's own
+    refresh interval, and a stale decision baked into static_rows would
+    leave the joined list wrongly shaped for that whole window instead of
+    only the readings inside it being stale.
+    """
+    if scene_rows and static_rows:
+        static_rows = [(SPACE, f"space.{static_rows[0][1]}", "")] + static_rows
+    return scene_rows + static_rows
+
+
+def build_rows(parsed: dict | None = None) -> list[tuple[str, str, str]]:
+    """Return the metadata view's rows for the frame on screen, scene and
+    static sections together in one call.
+
+    Every section is laid out in the same order every time, but only the
+    readings the stream carries survive it: a block this stream has no data
+    for takes no room, so what is on screen is what the bitstream said and
+    the sections that are there can be read without hunting between empty
+    ones.
+
+    A caller polling on its own timer -- ui.dvmetadata's dialogs, which need
+    build_scene_rows fresh on every tick and build_static_rows only on a
+    slower one -- should call the two halves and join_rows directly instead
+    of this; this single-call form is for a caller with no such split (a
+    one-shot dump, a caller passing its own parse result rather than reading
+    the side data live) that just wants every row at once.
+    """
+    scene_rows, parsed, origin, carried = build_scene_rows(parsed)
+    rows = join_rows(scene_rows, build_static_rows(parsed, origin, carried))
 
     if not rows:
         # Nothing was parsed at all -- no module, no side data, a frame that

--- a/resources/lib/info/properties.py
+++ b/resources/lib/info/properties.py
@@ -1,6 +1,7 @@
 """Compute and publish Window properties for TinyPPI.
 
-Call ``update_properties(window)`` once per polling interval, and
+Call ``publish_scene_properties(window)`` on every polling tick and
+``update_static_properties(window)`` on the slower one, and
 ``publish_properties(window)`` ahead of a window Kodi has not built yet.
 """
 
@@ -32,7 +33,7 @@ from core.utils import (
     is_effective_dv,
     parse_offsets,
     picture_aspect_ratio,
-    set_window_properties,
+    set_changed_properties,
 )
 from info.audioinfo import (
     get_active_audio_bit_depth,
@@ -682,18 +683,30 @@ def _channel_setting_for(hdr_type: str) -> str:
     return "channels_hdr"
 
 
-def publish_channel_visibility(home=None) -> None:
+def publish_channel_visibility(home=None, published=None) -> None:
     """Publish ``TinyPPI.ShowChannelIcon`` for the current output type.
 
     Re-read every poll rather than once at open: the HDR type is detected
     asynchronously, so a stream that turns out to be DV must switch to the DV
     setting while the overlay is up.  A fresh ``Addon()`` avoids its cached
     settings, so toggling one applies without reopening.
+
+    ``published`` tracks the polling loop's window; pass it from there to
+    skip the write when the setting hasn't changed.  Left unset, every call
+    writes unconditionally.
     """
     home = home or xbmcgui.Window(10000)
     setting = _channel_setting_for(home.getProperty("TinyPPI.EffectiveHdrType"))
     enabled = xbmcaddon.Addon().getSetting(setting) == "true"
-    home.setProperty("TinyPPI.ShowChannelIcon", "1" if enabled else "0")
+    if published is None:
+        published = {}
+    set_changed_properties(
+        home,
+        published,
+        (
+            ("TinyPPI.ShowChannelIcon", "1" if enabled else "0"),
+        ),
+    )
 
 
 def _effective_hdr_type(hdr_type: str) -> str:
@@ -743,7 +756,7 @@ def _hdr10_panel_stands_in_for_dv() -> bool:
     )
 
 
-def publish_hdr_type(home=None) -> None:
+def publish_hdr_type(home=None, published=None) -> None:
     """Publish the detected source HDR type as ``TinyPPI.HdrType`` on the Home
     window, plus the type the overlay layout follows as
     ``TinyPPI.EffectiveHdrType``.
@@ -754,61 +767,79 @@ def publish_hdr_type(home=None) -> None:
     The two differ once VS10 converts (see ``_effective_hdr_type``): the source
     stays HDR / DV -- the mode-select dialog and the ``Converting`` row need it
     to name what is being converted -- while the overlay follows the output.
+
+    ``published`` tracks the polling loop's window; pass it from there to
+    skip a write when neither value has changed.  Left unset, every call
+    writes unconditionally.
     """
     hdr_type = get_hdr_format()
     if hdr_type == "hdr10+":
         hdr_type = "hdr10plus"
     home = home or xbmcgui.Window(10000)
-    home.setProperty("TinyPPI.HdrType", hdr_type)
-    home.setProperty("TinyPPI.EffectiveHdrType", _effective_hdr_type(hdr_type))
+    if published is None:
+        published = {}
+    set_changed_properties(
+        home,
+        published,
+        (
+            ("TinyPPI.HdrType", hdr_type),
+            ("TinyPPI.EffectiveHdrType", _effective_hdr_type(hdr_type)),
+        ),
+    )
 
 
-def _set_progress(window, values: tuple[tuple[int, float], ...]) -> None:
-    """Publish a batch of progress-control percentages."""
+def _set_progress(window, published: dict, values: tuple[tuple[int, float], ...]) -> None:
+    """Publish a batch of progress-control percentages, skipping the ones
+    ``published`` already recorded at the same value."""
     for control_id, value in values:
-        window.getControl(control_id).setPercent(value)
+        key = f"__progress_{control_id}"
+        if published.get(key) != value:
+            window.getControl(control_id).setPercent(value)
+            published[key] = value
 
 
-def update_properties(window) -> None:
-    """Compute all player properties and refresh the progress controls.
+def update_static_properties(window, published=None) -> None:
+    """Compute the properties that settle at most once a title and refresh
+    the CPU-temperature progress control.
 
-    Call from the polling loop, and from anywhere else the window's controls
-    are known to exist -- ``_set_progress`` addresses one by id, which only
-    resolves once Kodi has loaded the window's XML.  Before that, and only
-    before that, use ``publish_properties``.
+    Call from the polling loop's slow cadence; ``publish_scene_properties``
+    covers the Dolby Vision / HDR10 readings that need the fast one instead.
+    ``_set_progress`` addresses a control by id, which only resolves once
+    Kodi has loaded the window's XML -- before that, and only before that,
+    use ``publish_properties``.
+
+    ``published`` tracks the polling loop's window across ticks, so an idle
+    tick costs no ``setProperty``/``setPercent`` calls; pass the loop's own
+    dict to get that.  Left unset, every call writes unconditionally.
     """
-    publish_properties(window)
+    if published is None:
+        published = {}
+    publish_static_properties(window, published)
     _set_progress(
         window,
+        published,
         (
             (9100, get_CpuTemperatureProgressVar()),
         ),
     )
 
 
-def publish_properties(window) -> None:
-    """Compute all player properties and publish them to ``window``.
+def publish_scene_properties(window, published=None) -> None:
+    """Publish the Dolby Vision / HDR10 readings that can move every scene:
+    the RPU's active-area offsets and L1 frame luminance come from the frame
+    on screen, not the title, so the aspect ratio and brightness rows can
+    change mid-playback (an IMAX Enhanced expansion, a brightness shift at a
+    scene cut) the way the rest of the overlay does not.  Also carries the
+    DV version and profile number, which don't move but are highlighted
+    alongside the rest by overlay.py and so need the same cadence.
 
-    Sets properties and nothing else, so it is safe on a window Kodi has not
-    built yet.  That is the point: called just before ``doModal()``, the values
-    are already in place when the window is first drawn, instead of arriving
-    with ``onInit()`` -- which Kodi dispatches to the script thread while the
-    window is on screen and fading in, leaving the rows empty until it lands.
+    ``published`` tracks the state of ``window``; pass the poll loop's own
+    dict to skip rewriting values that haven't changed.  Left unset, every
+    call writes unconditionally.
     """
-    publish_hdr_type()
-    # Depends on the type just published, and gates the channel graphics below.
-    publish_channel_visibility()
-
+    if published is None:
+        published = {}
     unit, pq_unit = _metadata_units()
-    fps_info_text, fps_out_text = fps_display_texts(
-        clean(info("Player.Process(videofps)"))
-    )
-
-    # Output-mode line from the stream's side data; fall back to a plain label
-    # from Kodi's ``VideoPlayer.HDRType`` when it would show N/A.
-    output_mode = get_output_mode()
-    if is_status_label(output_mode):
-        output_mode = _output_mode_from_videoplayer() or output_mode
 
     # The active-area offsets the RPU declares for the frame on screen, and
     # everything that follows from them: the icon beside the row, and the aspect
@@ -829,33 +860,23 @@ def publish_properties(window) -> None:
     rpu_mdl_from_source = get_rpu_mdl_from_source()
     l6_rpu_max_cll_fall = _with_unit(_separated(get_l6_rpu_max_cll_fall()), unit)
     # Only while the HDR panel stands in for the Dolby Vision one may the static
-    # rows borrow L6; the DV panel itself prints both as separate rows.
+    # rows borrow L6; the DV panel itself prints both as separate rows.  Reads
+    # the Home-window properties publish_static_properties last wrote, which
+    # may be up to a static-poll tick stale -- the type they describe settles
+    # at most once a title, so that is not a real staleness risk.
     l6_fallback         = _hdr10_panel_stands_in_for_dv()
     hdr10_mdl           = _with_unit(_separated(get_hdr10_mdl(l6_fallback)), unit)
     hdr10_max_cll_fall  = _with_unit(
         _separated(get_hdr10_max_cll_fall(l6_fallback)), unit
     )
 
-    set_window_properties(
+    set_changed_properties(
         window,
+        published,
         (
-            ("VideoDecoderVar", get_VideoDecoderVar()),
-            ("VideoDecoderLongVar", get_VideoDecoderLongVar()),
-            ("VideoPixelFormatVar", get_VideoPixelFormatVar()),
-            ("DisplayModeVar", get_DisplayModeVar()),
-            ("VideoResolutionVar", get_VideoResolutionVar()),
             ("AspectRatioVar", get_AspectRatioVar(l5_offsets)),
-            ("ImaxVar", get_ImaxVar()),
             ("DoviLevel5OffsetsVar", _separated(l5_offsets)),
             ("DoviLevel5OffsetsIconVisible", l5_icon_visible),
-            ("VideoBitrateMBVar", get_VideoBitrateMBVar()),
-            ("VideoLiveBitrateVar", get_VideoLiveBitrateVar()),
-            ("VideoCodecVar", get_VideoCodecVar()),
-            ("VideoDecoderNameVar", get_VideoDecoderNameVar()),
-            ("VideoBitDepthVar", get_VideoBitDepthVar()),
-            ("DoviProfileVar", output_mode),
-            ("MediaSourceVar", _media_source_name(output_mode)),
-            ("DoviTunnelVar", get_DoviTunnelVar()),
             ("DoviCmVersionVar", get_cm_version()),
             ("DoviStructureVar", get_structure()),
             ("DoviLevel1FllVar", l1_fll),
@@ -865,8 +886,72 @@ def publish_properties(window) -> None:
             ("DoviLevel6RpuMaxCllFallVar", l6_rpu_max_cll_fall),
             ("Hdr10MdlVar", hdr10_mdl),
             ("Hdr10MaxCllFallVar", hdr10_max_cll_fall),
+            # Format facts, not scene-variant, but overlay.py's
+            # _DV_VALUE_PROPERTIES highlights both: that mechanism rewrites a
+            # property plain again on the tick after it colors it, and relies
+            # on every name it tracks getting freshly recomputed every tick to
+            # do that.  On the slow cadence, a colored value would sit in
+            # ``published`` for up to a second and get wrapped in another
+            # [COLOR] layer on every tick in between instead of clearing.
             ("DoviVersionVar", get_dv_version()),
             ("DoviProfileNumberVar", get_dv_profile()),
+        ),
+    )
+
+
+def publish_static_properties(window, published=None) -> None:
+    """Publish the properties that settle at most once a title: video and
+    audio format facts, the Dolby Vision / HDR10 presence flags, and CPU
+    load.  ``publish_scene_properties`` covers the readings that can move
+    every scene instead, plus the DV version and profile number, which are
+    also format facts but need the fast cadence anyway because overlay.py
+    highlights them when they change.
+
+    Sets properties and nothing else, so it is safe on a window Kodi has not
+    built yet.  That is the point: called just before ``doModal()``, the values
+    are already in place when the window is first drawn, instead of arriving
+    with ``onInit()`` -- which Kodi dispatches to the script thread while the
+    window is on screen and fading in, leaving the rows empty until it lands.
+
+    ``published`` tracks the state of ``window``; pass the poll loop's own
+    dict to skip rewriting values that haven't changed.  Left unset, every
+    call writes unconditionally, which is what the pre-``doModal()`` caller
+    above needs on a window nothing has been published to yet.
+    """
+    if published is None:
+        published = {}
+    publish_hdr_type(published=published)
+    # Depends on the type just published, and gates the channel graphics below.
+    publish_channel_visibility(published=published)
+
+    fps_info_text, fps_out_text = fps_display_texts(
+        clean(info("Player.Process(videofps)"))
+    )
+
+    # Output-mode line from the stream's side data; fall back to a plain label
+    # from Kodi's ``VideoPlayer.HDRType`` when it would show N/A.
+    output_mode = get_output_mode()
+    if is_status_label(output_mode):
+        output_mode = _output_mode_from_videoplayer() or output_mode
+
+    set_changed_properties(
+        window,
+        published,
+        (
+            ("VideoDecoderVar", get_VideoDecoderVar()),
+            ("VideoDecoderLongVar", get_VideoDecoderLongVar()),
+            ("VideoPixelFormatVar", get_VideoPixelFormatVar()),
+            ("DisplayModeVar", get_DisplayModeVar()),
+            ("VideoResolutionVar", get_VideoResolutionVar()),
+            ("ImaxVar", get_ImaxVar()),
+            ("VideoBitrateMBVar", get_VideoBitrateMBVar()),
+            ("VideoLiveBitrateVar", get_VideoLiveBitrateVar()),
+            ("VideoCodecVar", get_VideoCodecVar()),
+            ("VideoDecoderNameVar", get_VideoDecoderNameVar()),
+            ("VideoBitDepthVar", get_VideoBitDepthVar()),
+            ("DoviProfileVar", output_mode),
+            ("MediaSourceVar", _media_source_name(output_mode)),
+            ("DoviTunnelVar", get_DoviTunnelVar()),
             ("DoviRpuPresentVar", get_dv_rpu_present()),
             ("DoviBlPresentVar", get_dv_bl_present()),
             ("DoviElPresentVar", get_dv_el_present()),
@@ -894,3 +979,20 @@ def publish_properties(window) -> None:
             ("CpuTopUsageVar", get_CpuTopUsageVar()),
         ),
     )
+
+
+def publish_properties(window, published=None) -> None:
+    """Publish every player property to ``window`` in one pass: a thin
+    wrapper combining ``publish_scene_properties`` and
+    ``publish_static_properties``, called once before ``doModal()`` so the
+    first frame's values are already in place before Kodi draws the window.
+    The polling loop calls the two halves separately afterward, each at its
+    own cadence.
+
+    ``published`` tracks the state of ``window``, same as in the two halves
+    this wraps.
+    """
+    if published is None:
+        published = {}
+    publish_scene_properties(window, published)
+    publish_static_properties(window, published)

--- a/resources/lib/ui/dvmetadata.py
+++ b/resources/lib/ui/dvmetadata.py
@@ -19,7 +19,7 @@ one thing it says of its own accord is which readings just moved -- a refresh
 writes those in the highlight color for as long as they keep moving, so a list
 this long can be read as a live one.  Which is also why a heading whose block
 this frame did not carry reads ``(Cached)``: what is on screen should say
-whether it is the frame's own (see _write).
+whether it is the frame's own (see _paint).
 """
 
 import threading
@@ -74,7 +74,7 @@ _HOME = 10000
 _SECTION_VIEW = "TinyPPI.MetadataSectionView"
 
 # A reading that moved since the last refresh is written in this color for the
-# one second it stays changed, so the eye finds what is live among rows that
+# one tick it stays changed, so the eye finds what is live among rows that
 # mostly stand still -- the trims and the frame luminance move with the
 # picture, the title-level blocks do not.  Its own setting (Metadata -> Changed
 # values), published by ui.theme like every other color.
@@ -91,11 +91,6 @@ _CHANGED_FALLBACK = "FF82B1FF"  # Light blue, the setting's own default
 # draw none.
 _RULE_TEXTURE = "common/dot-1x1.png"
 
-# A row that fills nothing, which is what the items left over from a longer
-# list are painted with: the list only ever grows, so a rebuild with fewer
-# rows blanks the surplus in place rather than removing it (see _fill).
-_BLANK_ROW = (dvmetadata.SPACE, "", "")
-
 # Property name each cell of a table row goes into: the skin has a label per
 # column reading one of these, so cell 0 lands in the first fixed slot, cell 1
 # in the second, and a cell nobody filled draws nothing.  Headings and
@@ -104,9 +99,20 @@ _CELL_HEADING = "h"
 _CELL_VALUE   = "c"
 
 # Seconds between refreshes, matching the overlay's own polling interval: the
-# per-frame blocks (L1, L5, the trims) move with the picture, so they are worth
-# re-reading, but not faster than a viewer can read them.
-_REFRESH = 1.0
+# per-frame blocks (L1, L5, the trims) move with the picture, so a slower tick
+# here would fall behind the same scene cuts the overlay already tracks.  The
+# guard in _fill (self._keys and self._last_labels) is what keeps a tick this
+# fast from touching the list on the ticks nothing in it changed.
+_REFRESH = 0.1
+
+# Seconds between fallback re-renders of dvmetadata.build_static_rows's half
+# of the list, matching the overlay's own static cadence: those sections
+# settle before the film was ever played, so re-deriving them on every
+# _REFRESH tick would recompute nine formatting passes a second for rows that
+# changed maybe once.  The rare change they do have is caught the tick it
+# lands by dvmetadata.static_signature, so this timer only covers what the
+# signature cannot see.  See _merged_rows.
+_STATIC_ROWS_INTERVAL = 1.0
 
 # Actions arriving within this many seconds of the window opening are ignored,
 # so the key press that opened it cannot immediately close it again.
@@ -184,13 +190,27 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         self._running   = False
         self._monitor   = xbmc.Monitor()
         self._opened_at = 0.0
-        # Row identities currently in the list, so a refresh that only changes
-        # values leaves the list itself alone, and the value each identity was
-        # last filled with, which is what a refresh highlights against.  Keyed
-        # by identity rather than by position so a rebuild does not lose it
-        # (see _identities).
+        # Row identities currently in the list, and the value each identity
+        # was last filled with, which is what a refresh highlights against.
+        # Keyed by identity rather than by position so a rebuild does not
+        # lose it (see _identities).
         self._keys: list = []
         self._values: dict = {}
+        # The label (or, for a table row, cell list) each row actually
+        # showed last tick, compared whole against a fresh tick's labels so
+        # an idle tick can return before it builds anything -- see _fill.
+        self._last_labels: list = []
+        # True from just before _fill's reset()/addItems() swap until the
+        # post-swap selection handling is done -- see _cursor_area.
+        self._swapping: bool = False
+        # The static half of the row list (see dvmetadata.build_static_rows),
+        # the signature of what it was rendered from, and when its fallback
+        # re-render is next due -- re-rendered the tick its blocks change and
+        # on _STATIC_ROWS_INTERVAL otherwise, rather than on every tick.
+        # _merged_rows() owns all three.
+        self._static_rows: list = []
+        self._static_signature = None
+        self._next_static_rows = 0.0
         self._closing        = False
         self._refresh_failed = False
         self._color_missing  = False
@@ -215,9 +235,44 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         self.back_to_caller = False
         self.open_section   = ""
 
+    def _merged_rows(self) -> list:
+        """The scene rows fresh from this tick, plus the static rows from
+        whichever tick last re-rendered them.
+
+        dvmetadata.build_scene_rows already does the live side-data read and
+        the DM-compression hold-fill every call; build_static_rows only
+        needs the parse result and origin map that call produced, not a
+        fresh read of its own, so re-rendering it is cheap to skip on the
+        ticks it is not due.  It re-renders the tick its own blocks actually
+        change (dvmetadata.static_signature) and on _STATIC_ROWS_INTERVAL
+        otherwise, so a scene cut that also moves the static half is not
+        left waiting on the fallback timer to catch up.  join_rows decides
+        the blank row between the two halves against THIS tick's scene_rows
+        every time, not against whichever tick last rebuilt
+        self._static_rows, so a stale cache cannot leave the joined list
+        wrongly shaped even while its readings are still stale.
+
+        The deadline and signature both advance before the call, not after,
+        the same reason overlay.py's update_static_properties does it in
+        that order: a failure below still counts this as tried, so it
+        retries in another _STATIC_ROWS_INTERVAL rather than every tick
+        until it succeeds.
+        """
+        scene_rows, parsed, origin, carried = dvmetadata.build_scene_rows()
+        signature = dvmetadata.static_signature(parsed, origin, carried)
+        now = time.time()
+        if signature != self._static_signature or now >= self._next_static_rows:
+            self._next_static_rows = now + _STATIC_ROWS_INTERVAL
+            self._static_signature = signature
+            self._static_rows = dvmetadata.build_static_rows(parsed, origin, carried)
+        rows = dvmetadata.join_rows(scene_rows, self._static_rows)
+        if not rows:
+            rows = [(dvmetadata.SECTION, "No metadata in this frame", "")]
+        return rows
+
     def _rows(self) -> list:
         """The rows to show: all of them.  A section view narrows this."""
-        return dvmetadata.build_rows()
+        return self._merged_rows()
 
     def onInit(self) -> None:
         self._running   = True
@@ -235,37 +290,6 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
 
     # --- List ---------------------------------------------------------------
 
-    @staticmethod
-    def _write(item: xbmcgui.ListItem, row: tuple, label) -> None:
-        """Put a row's value into whichever of the item's fields draws it.
-
-        A heading's value is not a reading but where the block under it came
-        from, so it goes into ``state``, which the skin draws after the title
-        in brackets -- ``L8 — Trims (Cached)`` for a section standing on a
-        block held from an earlier frame, and nothing after the title for one
-        the frame itself carried.  Beside the title and not in it: the title is
-        what the view finds the viewer's section by (see _area_index), and one
-        that changed with the frame would lose them.
-
-        A table row hands its cells over one property at a time, and clears the
-        ones it has no cell for -- the item is reused from refresh to refresh,
-        so a column that goes away has to be emptied rather than left holding
-        what it said last.
-        """
-        kind, _name, _value = row
-        if kind == dvmetadata.SECTION:
-            item.setProperty("state", label)
-            return
-        if kind not in (dvmetadata.HEADINGS, dvmetadata.COLUMNS):
-            item.setLabel2(label)
-            return
-        prefix = _CELL_HEADING if kind == dvmetadata.HEADINGS else _CELL_VALUE
-        for position in range(dvmetadata.MAX_COLUMNS):
-            item.setProperty(
-                f"{prefix}{position}",
-                label[position] if position < len(label) else "",
-            )
-
     @classmethod
     def _paint(cls, item: xbmcgui.ListItem, row: tuple, label) -> None:
         """Make *item* show *row*, with *label* as its value.
@@ -277,16 +301,18 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         layout is fed one of them and draws nothing when it comes back empty.
 
         A heading puts its title in the ``head`` property, which is the one
-        the large font is on, its ``(Cached)`` in ``state`` beside it (see
-        _write), and names the texture for the rule under it.  A two-column
-        row fills both labels.  A full-width line fills only the second, which
-        spans the row.  A table row fills a property per cell, which is what
-        puts each in a fixed column.  A blank row fills nothing.
+        the large font is on, its ``(Cached)`` in ``state`` beside it, and
+        names the texture for the rule under it.  A two-column row fills
+        both labels.  A full-width line fills only the second, which spans
+        the row.  A table row fills a property per cell, which is what puts
+        each in a fixed column.  A blank row fills nothing.
 
         Every field is written on every call, the unused ones with nothing:
-        items outlive the row that was on them -- a rebuild hands an item
-        whatever row now falls at its position -- so painting one is as much
-        about what it stops saying as about what it says.
+        the item is always a fresh one _fill just built for this one row, so
+        there is no earlier row's field left over to worry about -- but one
+        painter that always writes the whole shape is simpler than one that
+        has to know what an item said last, and it costs nothing extra on an
+        item that started out blank anyway.
         """
         kind, name, _value = row
         heading = kind == dvmetadata.SECTION
@@ -306,32 +332,6 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
             item.setProperty(f"{_CELL_VALUE}{position}",
                              cell if kind == dvmetadata.COLUMNS else "")
 
-    @classmethod
-    def _extend(cls, control: xbmcgui.ControlList, rows: list,
-                labels: list) -> int:
-        """Append the items a longer list needs, and say how many it had.
-
-        Appending is one message to the GUI thread, which applies it whole, so
-        the list is never drawn without its rows -- clearing it first is what
-        would be seen (see _fill).  The new items are painted before they are
-        handed over rather than after, for the same reason: what the GUI
-        thread binds is already the rows it should show, not blanks waiting to
-        be filled in.
-
-        The count returned is the one from before the append: those are the
-        items still holding an older row, and so the ones the caller has to
-        paint.
-        """
-        held = control.size()
-        if len(rows) > held:
-            items = []
-            for row, label in zip(rows[held:], labels[held:]):
-                item = xbmcgui.ListItem("", "")
-                cls._paint(item, row, label)
-                items.append(item)
-            control.addItems(items)
-        return held
-
     def _changed_color(self) -> str:
         """The highlight color the theme published, or the setting's own
         default when it did not -- and a line in the log saying so, since a
@@ -350,25 +350,76 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         return _CHANGED_FALLBACK
 
     def _fill(self, rows: list) -> None:
-        """Put *rows* in the list, reusing the items already in it.
+        """Put *rows* in the list, wholesale, on any tick something in it
+        changed; touch nothing at all on a tick that did not.
 
-        The values change every second; the rows they sit in almost never do.
-        Rewriting every row regardless would cost more than it buys, so a
-        refresh normally just writes the new values into the items that are
-        already there.  A structural change -- a stream that starts carrying
-        trim passes, a section the frame no longer has any readings for --
-        repaints all of them, and puts the viewer back on the section they
-        were reading rather than at the top of the list.
+        On-device measurement is why: Kodi meters every in-place
+        ListItem.setLabel*/setProperty call made from a background thread
+        through a once-per-frame GUI lock, so a single row write blocked
+        47-250ms at 23.976Hz, a 6-row update spanned 85-627ms, and a 72-row
+        in-place repaint ran 829ms -- against 4.8ms for the same 72 rows
+        through the bind path below.  The one fast path Kodi offers is the
+        initial fill, which hands the control a whole item list through one
+        addItems() bind message.  So a changed tick takes that path every
+        time: a fresh, unattached ListItem is built and painted for every
+        row -- offscreen items are unsynchronized by design, so populating
+        them off the GUI thread costs nothing here -- and only once that is
+        done does the tick touch the list at all: control.reset()
+        immediately followed by control.addItems(items), with no work
+        between the two so both messages queue for what is meant to be the
+        same dispatch pass -- not even a read of the control, now that the
+        viewport it will need back comes from two infolabels rather than
+        ControlList.getSelectedPosition(), which blocked behind the same
+        once-per-frame lock as the writes above, close to a frame on its own
+        (about 34ms measured) for a call that used to sit in this exact
+        spot.  That is design intent, not a settled fact: this file's
+        previous design never reset the list at all, on the reasoning that
+        Kodi is free to draw between any two calls however close together
+        they are issued, and an empty list mid-swap would flash visibly.
+        Whether Kodi can in fact draw between reset() and addItems() is the
+        one open question this design carries -- taken deliberately to the
+        device for verification rather than settled here, because the per-call
+        alternative is the one measured above.  An item already handed to
+        the control this way is never reached back into; the next changed
+        tick builds a whole new set instead.
 
-        What no refresh does is empty the list first.  Clearing a Kodi list
-        and refilling it are two separate messages to the GUI thread, which is
-        free to draw the list between them: a block appearing mid-film -- L2
-        or L8 arriving with a shot that needed trims -- would blank the whole
-        view for a frame or more before the rows came back.  So the list only
-        ever grows: items are appended when a rebuild wants more of them, and
-        the ones a shorter rebuild leaves over are blanked in place rather
-        than removed.  They cost nothing but a little empty room under the
-        last section, and the next block to arrive lands in them.
+        An idle tick -- the row identities and the labels they would show
+        are both exactly what the list is already showing -- returns before
+        any of that runs, so a still frame between scene cuts costs nothing.
+
+        Every addItems() bind ends, inside Kodi itself, in an unconditional
+        SelectItem(0) -- the jump to the top of the list is built into the
+        engine, not a gap this code leaves open.  A single selectItem(current)
+        afterward puts the cursor back on the right row but not the view
+        under it: from that zeroed offset, Kodi's own SelectItem places an
+        off-page row at the bottom of the viewport (offset = row - page + 1)
+        rather than where it sat before, so a row thirty deep into the list
+        reappears at its foot, and a frame rendered before a second call
+        corrects that shows a snap to the top followed by an animated crawl
+        back down.  Landing exactly on the old viewport instead takes two
+        selects, the idiom _focus_area already uses to open a section:
+        selectItem(first_visible + page - 1) first, page being however many
+        rows are on screen at once, which pins the far edge of the old page
+        without moving the cursor there, then selectItem(current), which
+        lands the cursor on a row already on screen -- the one case
+        SelectItem leaves the offset untouched.  first_visible itself comes
+        from two infolabels read before reset() touches anything:
+        Container(_LIST).Position, the cursor's slot within the viewport,
+        and .CurrentItem, its absolute index one-based, give first_visible =
+        (CurrentItem - 1) - Position.  Either read coming back empty or
+        unparsable leaves the viewport unknown rather than guessed at zero,
+        and a value-only refresh under those conditions makes no
+        selectItem() call at all, leaving the list wherever the bind's own
+        SelectItem(0) put it.
+
+        A structural change -- a stream that starts carrying trim passes, a
+        section the frame no longer has any readings for -- puts the viewer
+        back on the section they were reading rather than at the top of the
+        list, same as before.  A value-only change instead restores the
+        exact viewport the control had right before the swap, by the
+        two-select recipe above, so a refresh cannot move the viewer even
+        though every item under them is a different object than a moment
+        ago.
 
         Either way the values that moved go up in the highlight color, which
         is the whole point of a view that refreshes: with sixty rows on
@@ -382,7 +433,6 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         goes in and out of being held would spend half the film lit up as
         though something in it had changed.
         """
-        control = self.getControl(_LIST)
         keys   = _identities(rows)
         values = dict(zip(keys, (value for _kind, _name, value in rows)))
         color  = self._changed_color()
@@ -392,32 +442,51 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
             for row, key in zip(rows, keys)
         ]
 
-        if keys != self._keys:
-            held = self._extend(control, rows, labels)
-            for index in range(min(held, len(rows))):
-                self._paint(control.getListItem(index), rows[index],
-                            labels[index])
-            for index in range(len(rows), control.size()):
-                self._paint(control.getListItem(index), _BLANK_ROW, "")
-            self._keys  = keys
-            self._areas = _areas(rows)
-            self._resize(len(rows))
-            self._focus_area(self._area_index())
-        else:
-            for index, (row, label) in enumerate(zip(rows, labels)):
-                self._write(control.getListItem(index), row, label)
+        if keys == self._keys and labels == self._last_labels:
+            return
 
-        self._values = values
+        items = []
+        for row, label in zip(rows, labels):
+            item = xbmcgui.ListItem("", "", offscreen=True)
+            self._paint(item, row, label)
+            items.append(item)
+
+        control = self.getControl(_LIST)
+        self._swapping = True
+        try:
+            try:
+                slot    = int(xbmc.getInfoLabel(f"Container({_LIST}).Position"))
+                current = int(xbmc.getInfoLabel(f"Container({_LIST}).CurrentItem")) - 1
+            except Exception:
+                current = -1
+            first_visible = max(0, current - slot) if current >= 0 else 0
+            control.reset()
+            control.addItems(items)
+
+            if keys != self._keys:
+                self._keys  = keys
+                self._areas = _areas(rows)
+                self._resize(len(rows))
+                self._focus_area(self._area_index())
+            elif 0 <= current < len(items):
+                page   = max(1, min(len(items), _MAX_ROWS))
+                anchor = min(first_visible + page - 1, len(items) - 1)
+                control.selectItem(anchor)
+                control.selectItem(current)
+        finally:
+            self._swapping = False
+
+        self._values      = values
+        self._last_labels = labels
 
     # --- Geometry -----------------------------------------------------------
 
     def _resize(self, shown: int) -> None:
         """Cut the window down to the *shown* rows it has to hold.
 
-        The list keeps every item it has ever been given -- blanking the ones
-        a shorter refresh leaves over rather than removing them, which is what
-        keeps it from blinking (see _fill) -- so the height comes from the row
-        count passed in, not from the size of the control's own list.
+        Called with the row count _fill rebuilt the list to, from the same
+        call that just swapped it in -- there is no reason to ask the
+        control what it holds when the caller already knows.
 
         Everything below the list moves with its foot and the panel ends under
         that, so what is drawn is the rows and their frame, with no empty
@@ -502,7 +571,14 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         jumped to: the arrow keys are not the only way to move a Kodi list --
         the scrollbar and a mouse move it too -- and OK should open what the
         viewer is looking at however they got there.
+
+        Answers with the section already on screen while self._swapping is
+        set: a keypress can land between _fill's reset() and its addItems(),
+        and the control would read position 0 out of a list that is
+        momentarily empty.
         """
+        if self._swapping:
+            return self._area_title
         try:
             position = self.getControl(_LIST).getSelectedPosition()
         except Exception:
@@ -570,10 +646,11 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
     # --- Refresh ------------------------------------------------------------
 
     def _update_loop(self) -> None:
-        """Re-read the side data once a second until the view should close.
+        """Re-read the side data every _REFRESH seconds until the view should
+        close.
 
         Mirrors the overlay's loop, and for the same reasons: a failed refresh
-        costs one stale second rather than the window, and the close runs from
+        costs one stale tick rather than the window, and the close runs from
         ``finally`` so an unforeseen failure still puts the view away instead
         of leaving it up and frozen over the film.
         """
@@ -600,7 +677,7 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
 
     def _log_refresh_failure(self, exc: Exception) -> None:
         """Log a failed refresh once per view, so a persistent fault leaves a
-        trace without writing to the log every second."""
+        trace without writing to the log every tick."""
         if self._refresh_failed:
             return
         self._refresh_failed = True
@@ -636,12 +713,18 @@ class DVSectionDialog(DVMetadataDialog):
     def _rows(self) -> list:
         """The rows of this section alone, heading included.
 
-        Sliced out of the whole list each refresh rather than kept, because
+        Sliced out of the merged list each refresh rather than kept, because
         the section is live: a trim pass the frame adds belongs in here too.
         A stream that stops carrying the block entirely leaves the heading, so
         the window says what it is standing on rather than going blank.
+        Slicing from self._merged_rows() rather than a fresh
+        dvmetadata.build_rows() call means a section on the static side
+        (L9, the RPU header, and the rest -- see dvmetadata.build_static_rows)
+        re-renders the tick its own blocks change and on that half's fallback
+        cadence otherwise, same as it would be in the full list; only a scene
+        section is fresh every tick either way.
         """
-        rows = dvmetadata.build_rows()
+        rows = self._merged_rows()
         for start, title, end in _areas(rows):
             if title == self.section:
                 return rows[start:end + 1]

--- a/resources/lib/ui/dvmetadata.py
+++ b/resources/lib/ui/dvmetadata.py
@@ -114,6 +114,11 @@ _REFRESH = 0.1
 # signature cannot see.  See _merged_rows.
 _STATIC_ROWS_INTERVAL = 1.0
 
+# Seconds join_update_loop gives the refresh thread to wind down: far past
+# the tick it may still be sleeping through, so a live thread always makes it
+# and a wedged one does not hold the hand-off for good.
+_JOIN_TIMEOUT = 1.0
+
 # Actions arriving within this many seconds of the window opening are ignored,
 # so the key press that opened it cannot immediately close it again.
 _SETTLE = 0.3
@@ -211,6 +216,7 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         self._static_rows: list = []
         self._static_signature = None
         self._next_static_rows = 0.0
+        self._thread         = None
         self._closing        = False
         self._refresh_failed = False
         self._color_missing  = False
@@ -286,7 +292,30 @@ class DVMetadataDialog(xbmcgui.WindowXMLDialog):
         except Exception as exc:
             self._log_refresh_failure(exc)
         self.setFocusId(_LIST)
-        threading.Thread(target=self._update_loop, daemon=True).start()
+        self._thread = threading.Thread(target=self._update_loop, daemon=True)
+        self._thread.start()
+
+    def join_update_loop(self) -> None:
+        """Wait for the refresh thread to actually stop.
+
+        Mirrors ui.overlay.TinyPPIDialog.join_update_loop: the loop only
+        checks self._running between ticks, so it can outlive doModal() by
+        up to one tick, still writing to a window Kodi is tearing down and
+        still touching info.dvmetadata's module-level _held / _held_source
+        that the next view's own loop reads.  Called after doModal() so the
+        hand-over to the next view waits for it instead of racing it.  Logs
+        once if the thread is still alive after the timeout -- a wedged
+        thread can only happen once per dialog instance, so an unconditional
+        log on that path is enough.
+        """
+        if self._thread is not None:
+            self._thread.join(_JOIN_TIMEOUT)
+            if self._thread.is_alive():
+                xbmc.log(
+                    f"TinyPPI: refresh thread still running after "
+                    f"{_JOIN_TIMEOUT}s, handing over anyway",
+                    xbmc.LOGWARNING,
+                )
 
     # --- List ---------------------------------------------------------------
 
@@ -776,6 +805,7 @@ def _show_section(title: str) -> bool:
         dialog = _dialog(DVSectionDialog)
         dialog.section = title
         dialog.doModal()
+        dialog.join_update_loop()
         back_to_list = dialog.back_to_caller
         del dialog
     finally:
@@ -797,6 +827,7 @@ def open_dv_metadata() -> bool:
         dialog = _dialog(DVMetadataDialog)
         dialog.start_section = section
         dialog.doModal()
+        dialog.join_update_loop()
         section         = dialog.open_section
         back_to_overlay = dialog.back_to_caller
         del dialog

--- a/resources/lib/ui/overlay.py
+++ b/resources/lib/ui/overlay.py
@@ -96,6 +96,12 @@ _DV_VALUE_PROPERTIES = (
 _DV_CHANGED_COLOR    = "TinyPPI.OutputChangedColor"
 _DV_CHANGED_FALLBACK = "FF82B1FF"  # Light blue, the setting's default
 
+# How often the tick loop refreshes properties.update_static_properties.
+# Video/audio/subtitle facts and CPU stats settle at most once a title, so
+# they do not need the loop's own 100ms cadence the way the Dolby Vision /
+# HDR10 readings in publish_scene_properties do.
+_STATIC_POLL_INTERVAL = 1.0
+
 
 def _is_coreelec() -> bool:
     """Return True when running on a CoreELEC installation."""
@@ -236,6 +242,10 @@ class TinyPPIDialog(xbmcgui.WindowXMLDialog):
         self._dv_channel_offset = None
         self._refresh_failed    = False
         self._dv_values: dict   = {}
+        # Not underscore-prefixed: _show_overlay() seeds this from outside the
+        # class, the same way next_view below is read from outside once doModal()
+        # returns.
+        self.published: dict    = {}
         self._color_missing     = False
         # Read by open_tinyppi() once doModal() returns; see _open_dv_metadata.
         self.next_view  = None
@@ -281,24 +291,26 @@ class TinyPPIDialog(xbmcgui.WindowXMLDialog):
     def _highlight_dv_changes(self) -> None:
         """Highlight DV readings that moved during the latest refresh.
 
-        ``properties.update_properties`` has just replaced every property with
-        its uncolored current value.  Compare those against the plain values
-        remembered from the previous pass, publish the marked display strings,
-        then retain the plain values for next time.  A continuously moving
-        reading therefore stays highlighted; after one stable pass it returns
-        to the normal output color.
+        Reads current values from ``self.published`` rather than back from
+        the window: whichever publish call last touched a given property (the
+        fast scene pass or the slower static one) already recorded its plain
+        current value there regardless of whether it needed a fresh
+        ``setProperty`` call.  The colored variant written here also goes
+        back into ``self.published``, so the next pass's plain recompute
+        reads as a change against it and clears the highlight, instead of
+        leaving it stuck.  A stable reading therefore costs nothing here.
         """
         current = {
-            name: self.getProperty(name) for name in _DV_VALUE_PROPERTIES
+            name: self.published.get(name, "") for name in _DV_VALUE_PROPERTIES
         }
-        hdr_type = xbmcgui.Window(10000).getProperty("TinyPPI.HdrType").lower()
+        hdr_type = self.published.get("TinyPPI.HdrType", "").lower()
         if "dolby" in hdr_type:
             color = self._dv_changed_color()
             for name, value in current.items():
-                self.setProperty(
-                    name,
-                    highlight_changes(self._dv_values.get(name), value, color),
-                )
+                highlighted = highlight_changes(self._dv_values.get(name), value, color)
+                if self.published.get(name) != highlighted:
+                    self.setProperty(name, highlighted)
+                    self.published[name] = highlighted
         self._dv_values = current
 
     def _base_offset(self) -> tuple:
@@ -452,15 +464,25 @@ class TinyPPIDialog(xbmcgui.WindowXMLDialog):
         t.start()
 
     def _update_loop(self) -> None:
-        """Refresh the overlay once a second until it should close.
+        """Refresh the overlay every 100ms until it should close.
+
+        Only ``publish_scene_properties`` runs on every tick: it is the
+        Dolby Vision / HDR10 readings there that can move every scene.
+        Everything else settles at most once a title, so
+        ``update_static_properties`` runs on its own, slower
+        ``_STATIC_POLL_INTERVAL`` timer instead of every tick.
+
+        ``self.published`` makes both cadences cheap: whichever pass ran,
+        an idle tick costs no ``setProperty`` calls, only the recompute.
 
         A failed refresh never ends the loop: the values come from the player
         and from the stream's side data, so a bad cycle is worth one stale
-        second, not a window that stops auto-closing.  ``close_dialog`` runs
+        tick, not a window that stops auto-closing.  ``close_dialog`` runs
         from ``finally`` so even an unforeseen failure still releases the
         overlay instead of leaving it up, frozen and marked active.
         """
         player = xbmc.Player()
+        next_static_publish = 0.0
 
         try:
             while self._running and not self._monitor.abortRequested():
@@ -472,13 +494,22 @@ class TinyPPIDialog(xbmcgui.WindowXMLDialog):
                     break
 
                 try:
-                    properties.update_properties(self)
+                    properties.publish_scene_properties(self, self.published)
                     self._highlight_dv_changes()
                     self._apply_position_offset()
+
+                    now = time.time()
+                    if now >= next_static_publish:
+                        # Advance the deadline before the call, not after: a
+                        # failure below still counts this as tried, so it
+                        # retries in another _STATIC_POLL_INTERVAL rather than
+                        # every tick until it happens to succeed.
+                        next_static_publish = now + _STATIC_POLL_INTERVAL
+                        properties.update_static_properties(self, self.published)
                 except Exception as exc:
                     self._log_refresh_failure(exc)
 
-                if self._monitor.waitForAbort(1):
+                if self._monitor.waitForAbort(0.1):
                     break
         finally:
             self.close_dialog()
@@ -530,7 +561,7 @@ def _show_overlay(home) -> str | None:
     # published there arrives after the viewer is already looking at the
     # rows; done here, the first frame carries the values.  Properties only
     # -- the controls the full refresh touches do not exist yet.
-    properties.publish_properties(dialog)
+    properties.publish_properties(dialog, dialog.published)
     dialog.doModal()
     next_view = dialog.next_view
     del dialog

--- a/resources/lib/ui/overlay.py
+++ b/resources/lib/ui/overlay.py
@@ -102,6 +102,11 @@ _DV_CHANGED_FALLBACK = "FF82B1FF"  # Light blue, the setting's default
 # HDR10 readings in publish_scene_properties do.
 _STATIC_POLL_INTERVAL = 1.0
 
+# Seconds join_update_loop gives the refresh thread to wind down: far past
+# the tick it may still be sleeping through, so a live thread always makes it
+# and a wedged one does not hold the hand-off for good.
+_JOIN_TIMEOUT = 1.0
+
 
 def _is_coreelec() -> bool:
     """Return True when running on a CoreELEC installation."""
@@ -239,6 +244,7 @@ class TinyPPIDialog(xbmcgui.WindowXMLDialog):
         self._auto_hide = 0
         self._nudge     = (0, 0)
         self._nudge_on  = False
+        self._thread    = None
         self._dv_channel_offset = None
         self._refresh_failed    = False
         self._dv_values: dict   = {}
@@ -460,8 +466,29 @@ class TinyPPIDialog(xbmcgui.WindowXMLDialog):
         self.close_dialog()
 
     def _start_update_loop(self) -> None:
-        t = threading.Thread(target=self._update_loop, daemon=True)
-        t.start()
+        self._thread = threading.Thread(target=self._update_loop, daemon=True)
+        self._thread.start()
+
+    def join_update_loop(self) -> None:
+        """Wait for the update loop to actually stop.
+
+        The loop only checks self._running between ticks, so it can outlive
+        doModal() by up to one tick -- still writing to a window Kodi is
+        tearing down, and still reading the side-data hold state the next
+        view's loop reads (info.dvmetadata's module-level _held /
+        _held_source).  The hand-over to the next view waits here instead of
+        racing it.  Logs once if the thread is still alive after the
+        timeout -- a wedged thread can only happen once per dialog instance,
+        so an unconditional log on that path is enough.
+        """
+        if self._thread is not None:
+            self._thread.join(_JOIN_TIMEOUT)
+            if self._thread.is_alive():
+                xbmc.log(
+                    f"TinyPPI: refresh thread still running after "
+                    f"{_JOIN_TIMEOUT}s, handing over anyway",
+                    xbmc.LOGWARNING,
+                )
 
     def _update_loop(self) -> None:
         """Refresh the overlay every 100ms until it should close.
@@ -563,6 +590,7 @@ def _show_overlay(home) -> str | None:
     # -- the controls the full refresh touches do not exist yet.
     properties.publish_properties(dialog, dialog.published)
     dialog.doModal()
+    dialog.join_update_loop()
     next_view = dialog.next_view
     del dialog
     return next_view


### PR DESCRIPTION
The per scene readings in the overlay and the DV metadata view (L1, the trims, L5, L3, HDR10+) refreshed once a second, so they trailed the scene cuts they describe. This polls them at 100ms while keeping the title level readings on the old one second cadence.

The faster rate does not spend CPU on wasted work. The side data is only re-parsed when the underlying label actually changes, the slow half of the metadata view is only re-rendered when a change check on its source blocks says something moved, and a tick where nothing changed makes no GUI calls at all. Idle ticks come out cheaper than they were at the old rate.

The metadata view also stops repainting list rows in place. Kodi throttles item writes from addon threads to a narrow window each frame, so a scene cut visibly swept down the panel while its rows updated one by one, in the worst case over most of a second. A changed tick now builds the rows off screen and swaps the whole list in one GUI message, which measured under 5ms for the full list on an Amlogic box. Scroll position is preserved across the swap.

The refresh thread is joined when the views hand over, so two refresh loops can never overlap.

Tested on an Amlogic CoreELEC box during playback at 23.976Hz.
