### PR TITLE
Update strings.po

### DIFF
--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -121,7 +121,7 @@ msgstr "Bitráta"
 
 msgctxt "#32051"
 msgid "Input"
-msgstr "Hangforrás"
+msgstr "Forrás"
 
 msgctxt "#32052"
 msgid "Audio language"


### PR DESCRIPTION
Updated. Because the Video input and Audio channel input same string.
Maybe would be nice separate strings for the two. 
Thanks.

Just one question more:
Why is one Input in the Processing section, which is show DV with profile, HDR. SDR etc.
Then Media source, was shown same HDR, SDR and DV without DV profile?

Maybe you can add instead of the codec/resolution, 
like : 4K - UHD HEVC. Just an idea.. 