### PR TITLE
Add Hungarian translations for output and Dolby Vision

### DIFF
--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -143,6 +143,10 @@ msgctxt "#32056"
 msgid "Audio"
 msgstr "Hang"
 
+msgctxt "#32057"
+msgid "Output"
+msgstr "Kép kimenet"
+
 msgctxt "#32069"
 msgid "Audio resolution"
 msgstr "Hangfelbontás"
@@ -1498,6 +1502,14 @@ msgstr "Ez a forrás nem tartalmaz Dolby Vision RPU-t, így nincs mit megjelení
 msgctxt "#32472"
 msgid "Dolby Vision"
 msgstr "Dolby Vision"
+
+msgctxt "#32473"
+msgid "Display reset on Dolby Vision switch"
+msgstr "Képkimenet reset a Dolby Vision VS10 kapcsolásnál"
+
+msgctxt "#32474"
+msgid "Re-initialise the HDMI output whenever a VS10 switch turns Dolby Vision on or off. Kodi only re-applies the display mode when a stream's HDR type changes, which a switch made during playback never reports, so the TV keeps the previous signalling and the picture comes out with the wrong colours - most visibly in Player-LED mode. Turn it off if your TV or receiver dislikes the short re-sync."
+msgstr "Inicializáld újra a HDMI kimenetet, valahányszor egy VS10 kapcsoló be- vagy kikapcsolja a Dolby Visiont. A Kodi csak akkor alkalmazza újra a megjelenítési módot, ha egy stream HDR típusa megváltozik, amit a lejátszás közbeni váltás soha nem jelez, így a TV megtartja az előző jeltípust, és a kép rossz színekkel jelenik meg - leginkább a Player-LED módban. Kapcsold ki, ha ez problémákat okoz."
 
 msgctxt "#32494"
 msgid "Playback controls"


### PR DESCRIPTION
msgctxt "#32057"
msgid "Output"
msgstr "Kép kimenet"

I added one plus string, because the "#32055" "Output"  by me the Sound output, and same string in web view determinate the VS10 Picture output. 
Please add this separate, or one another, what you like separate to that. 
Thank you again. 

I noticed in the settings, Display reset on Dolby Vision switch is on by default, but that cause switching in TV led mode, in my box.
So I switched off.