### PR TITLE
Add missing dashboard translations for Arabic, Hungarian, and Chinese

### DIFF
--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -1484,6 +1484,74 @@ msgctxt "#32472"
 msgid "Dolby Vision"
 msgstr "دولبي فيجن"
 
+msgctxt "#32476"
+msgid "Frame drops"
+msgstr "تساقط الإطارات"
+
+msgctxt "#32478"
+msgid "Output switches"
+msgstr "تبديلات الإخراج"
+
+msgctxt "#32479"
+msgid "Events"
+msgstr "الأحداث"
+
+msgctxt "#32480"
+msgid "Nothing out of the ordinary yet"
+msgstr "لا شيء غير معتاد حتى الآن"
+
+msgctxt "#32481"
+msgid "1 min"
+msgstr "دقيقة واحدة"
+
+msgctxt "#32482"
+msgid "10 min"
+msgstr "10 دقائق"
+
+msgctxt "#32483"
+msgid "Whole title"
+msgstr "العنوان كاملاً"
+
+msgctxt "#32484"
+msgid "Audio track"
+msgstr "المسار الصوتي"
+
+msgctxt "#32485"
+msgid "Subtitles"
+msgstr "الترجمة"
+
+msgctxt "#32486"
+msgid "Off"
+msgstr "إيقاف"
+
+msgctxt "#32487"
+msgid "Volume"
+msgstr "مستوى الصوت"
+
+msgctxt "#32488"
+msgid "Mute"
+msgstr "كتم الصوت"
+
+msgctxt "#32489"
+msgid "Play / Pause"
+msgstr "تشغيل / إيقاف مؤقت"
+
+msgctxt "#32490"
+msgid "Stop"
+msgstr "إيقاف التشغيل"
+
+msgctxt "#32491"
+msgid "Display mode"
+msgstr "وضع العرض"
+
+msgctxt "#32492"
+msgid "Cache dip"
+msgstr "انخفاض الكاش"
+
+msgctxt "#32493"
+msgid "Frames lost"
+msgstr "إطارات مفقودة"
+
 msgctxt "#32494"
 msgid "Playback controls"
 msgstr "عناصر التحكم في التشغيل"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -1483,6 +1483,74 @@ msgctxt "#32472"
 msgid "Dolby Vision"
 msgstr "Dolby Vision"
 
+msgctxt "#32476"
+msgid "Frame drops"
+msgstr "Kockakiesés"
+
+msgctxt "#32478"
+msgid "Output switches"
+msgstr "Kimenetváltások"
+
+msgctxt "#32479"
+msgid "Events"
+msgstr "Események"
+
+msgctxt "#32480"
+msgid "Nothing out of the ordinary yet"
+msgstr "Eddig semmi rendellenes"
+
+msgctxt "#32481"
+msgid "1 min"
+msgstr "1 perc"
+
+msgctxt "#32482"
+msgid "10 min"
+msgstr "10 perc"
+
+msgctxt "#32483"
+msgid "Whole title"
+msgstr "Teljes cím"
+
+msgctxt "#32484"
+msgid "Audio track"
+msgstr "Hangsáv"
+
+msgctxt "#32485"
+msgid "Subtitles"
+msgstr "Feliratok"
+
+msgctxt "#32486"
+msgid "Off"
+msgstr "Ki"
+
+msgctxt "#32487"
+msgid "Volume"
+msgstr "Hangerő"
+
+msgctxt "#32488"
+msgid "Mute"
+msgstr "Némítás"
+
+msgctxt "#32489"
+msgid "Play / Pause"
+msgstr "Lejátszás / Szünet"
+
+msgctxt "#32490"
+msgid "Stop"
+msgstr "Leállítás"
+
+msgctxt "#32491"
+msgid "Display mode"
+msgstr "Megjelenítési mód"
+
+msgctxt "#32492"
+msgid "Cache dip"
+msgstr "Puffer-visszaesés"
+
+msgctxt "#32493"
+msgid "Frames lost"
+msgstr "Elveszett képkockák"
+
 msgctxt "#32494"
 msgid "Playback controls"
 msgstr "Lejátszásvezérlők"

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -1483,6 +1483,74 @@ msgctxt "#32472"
 msgid "Dolby Vision"
 msgstr "杜比视界"
 
+msgctxt "#32476"
+msgid "Frame drops"
+msgstr "丢帧"
+
+msgctxt "#32478"
+msgid "Output switches"
+msgstr "输出切换"
+
+msgctxt "#32479"
+msgid "Events"
+msgstr "事件"
+
+msgctxt "#32480"
+msgid "Nothing out of the ordinary yet"
+msgstr "暂无异常"
+
+msgctxt "#32481"
+msgid "1 min"
+msgstr "1 分钟"
+
+msgctxt "#32482"
+msgid "10 min"
+msgstr "10 分钟"
+
+msgctxt "#32483"
+msgid "Whole title"
+msgstr "整个影片"
+
+msgctxt "#32484"
+msgid "Audio track"
+msgstr "音轨"
+
+msgctxt "#32485"
+msgid "Subtitles"
+msgstr "字幕"
+
+msgctxt "#32486"
+msgid "Off"
+msgstr "关闭"
+
+msgctxt "#32487"
+msgid "Volume"
+msgstr "音量"
+
+msgctxt "#32488"
+msgid "Mute"
+msgstr "静音"
+
+msgctxt "#32489"
+msgid "Play / Pause"
+msgstr "播放 / 暂停"
+
+msgctxt "#32490"
+msgid "Stop"
+msgstr "停止"
+
+msgctxt "#32491"
+msgid "Display mode"
+msgstr "显示模式"
+
+msgctxt "#32492"
+msgid "Cache dip"
+msgstr "缓存下降"
+
+msgctxt "#32493"
+msgid "Frames lost"
+msgstr "丢失帧数"
+
 msgctxt "#32494"
 msgid "Playback controls"
 msgstr "播放控制"


### PR DESCRIPTION
The web dashboard's summary figures, history chart range picker, transport row and event labels (#32476, #32478-#32493) were only present in en_gb and de_de, so Kodi fell back to English for Arabic, Hungarian and Simplified Chinese.

Translate all 17 entries in each catalogue, inserted in ID order between #32472 and #32494 to match the existing layout.