### PR TITLE
Align HLG handling with HDR10+ by removing VS10 modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,11 @@ on-screen VS10 dialog offers, SDR sources included — and a tap applies one.
 The switch is handed to the add-on's own `run_mode` entry point, so it takes
 exactly the path a keymap shortcut takes, native VS10 actions included.
 
-**HDR10+** is the one source with no modes: the driver has no VS10 group for
-it, and the on-screen dialog draws none either. The dashboard follows, and
-hides the whole VS10 card — output line included — for the length of an
-HDR10+ stream. HDR10 keeps its three.
+**HDR10+** and **HLG** are the two sources with no modes: neither is a VS10
+input, so the driver has no group for either and the on-screen dialog draws
+none — both are left with the player-process button alone. The dashboard
+follows, and hides the whole VS10 card — output line included — for the length
+of an HDR10+ or HLG stream. HDR10 keeps its three.
 
 Switching **always** requires the access token, whatever reading is set to.
 
@@ -407,6 +408,9 @@ RunScript(script.tinyppi,dialog)
 ```
 
 Opens the VS10 mode selection dialog instead of the main TinyPPI overlay.
+It shows the modes that apply to the playing source; on an **HDR10+** or
+an **HLG** stream — neither of which is a VS10 input — it draws no modes at
+all and leaves the player-process button on its own.
 
 ### Apply a VS10 output mode directly
 

--- a/resources/lib/ui/mode_select.py
+++ b/resources/lib/ui/mode_select.py
@@ -258,7 +258,10 @@ def original_hdr() -> None:
 
 def original_hlg() -> None:
     # HLG is not a valid VS10 input, so turn VS10 off to let HLG pass through
-    # the standard HDR path untouched.  Follow-source with enable=N is the state
+    # the standard HDR path untouched.  That is also why neither the dialog nor
+    # the dashboard offers HLG any modes at all; this one is left reachable
+    # through ``run_mode`` for a keymap that wants to clear a VS10 mode an
+    # earlier title left behind.  Follow-source with enable=N is the state
     # Kodi itself leaves the driver in when it releases Dolby Vision; policy 0 is
     # follow-sink, a different thing, and not what "off" means here.
     _write_sequence(
@@ -509,10 +512,6 @@ _ACTIONS = {
     1005: "original_hdr",
     1006: "sdr8",
     1008: "dv",
-    # HLG (Original bypasses VS10 so HLG stays HLG)
-    1009: "original_hlg",
-    1010: "sdr8",
-    1011: "dv",
     # DV
     1012: "original_dv",
     1013: "sdr8",

--- a/resources/lib/web/snapshot.py
+++ b/resources/lib/web/snapshot.py
@@ -996,11 +996,6 @@ _VS10_OPTIONS = {
         ("sdr8",         "HDR10 → SDR"),
         ("dv",           "HDR10 → Dolby Vision"),
     ),
-    "hlg": (
-        ("original_hlg", "HLG (Original)"),
-        ("sdr8",         "HLG → SDR"),
-        ("dv",           "HLG → Dolby Vision"),
-    ),
     "dolby vision": (
         ("original_dv",  "Dolby Vision (Original)"),
         ("sdr8",         "Dolby Vision → SDR"),
@@ -1019,16 +1014,25 @@ def _is_hdr10_plus(key: str) -> bool:
     return "hdr10plus" in key or "hdr10+" in key
 
 
+def _has_no_modes(key: str) -> bool:
+    """Whether the lower-cased source token names a format VS10 cannot convert.
+
+    HDR10+ and HLG are the two, and neither is a VS10 input: the driver has no
+    group for either, and the on-screen dialog now draws none for either --
+    both are left with the player-process button alone (see
+    script-tinyppi-dialog.xml).
+    """
+    return _is_hdr10_plus(key) or "hlg" in key
+
+
 def _options_for(source: str, playing: bool = True) -> tuple:
     """The mode buttons that apply to ``source``.
 
-    ``hdr10plus`` gets none.  The driver has no VS10 group for it and the
-    on-screen dialog draws none either -- its HDR10 group is behind
-    ``String.IsEqual(...,hdr10)``, which HDR10+ does not match, and the only
-    control it leaves standing is the player-process button (see
-    script-tinyppi-dialog.xml).  The page follows: with no options the whole
-    VS10 card goes, output line included, rather than offer a conversion that
-    is not on offer anywhere else.
+    ``hdr10plus`` and ``hlg`` get none -- see ``_has_no_modes``: neither is a
+    VS10 input, so the dialog leaves both with the player-process button alone.
+    The page follows: with no options the whole VS10 card goes, output line
+    included, rather than offer a conversion that is not on offer anywhere
+    else.
 
     An **empty** source is SDR, not "unknown": ``publish_hdr_type`` writes a
     token only for the HDR formats, and the dialog's own SDR group is the one
@@ -1038,12 +1042,10 @@ def _options_for(source: str, playing: bool = True) -> tuple:
     if not playing:
         return ()
     key = (source or "").strip().lower()
-    if _is_hdr10_plus(key):
+    if _has_no_modes(key):
         return ()
     if "dolby" in key:
         return _VS10_OPTIONS["dolby vision"]
-    if "hlg" in key:
-        return _VS10_OPTIONS["hlg"]
     if "hdr10" in key:
         return _VS10_OPTIONS["hdr10"]
     return _VS10_OPTIONS["sdr"]

--- a/resources/skins/Default/1080i/script-tinyppi-dialog.xml
+++ b/resources/skins/Default/1080i/script-tinyppi-dialog.xml
@@ -97,7 +97,7 @@
 
             <!-- Player Process Info -->
             <control type="button" id="1001">
-                <visible>!String.IsEqual(Window(10000).Property(TinyPPI.HdrType),hdr10plus)</visible>
+                <visible>!String.IsEqual(Window(10000).Property(TinyPPI.HdrType),hdr10plus) + !String.Contains(Window(10000).Property(TinyPPI.HdrType),hlg)</visible>
                 <left>35</left>
                 <top>155</top>
                 <width>400</width>
@@ -112,17 +112,15 @@
                 <texturefocus colordiffuse="$INFO[Window(10000).Property(TinyPPI.DialogFocusColor)]" border="40">common/button-white.png</texturefocus>
                 <onup condition="String.IsEmpty(Window(10000).Property(TinyPPI.HdrType))">1004</onup>
                 <onup condition="String.IsEqual(Window(10000).Property(TinyPPI.HdrType),hdr10)">1008</onup>
-                <onup condition="String.Contains(Window(10000).Property(TinyPPI.HdrType),hlg)">1011</onup>
                 <onup condition="String.Contains(Window(10000).Property(TinyPPI.HdrType),dolby)">1013</onup>
                 <ondown condition="String.IsEmpty(Window(10000).Property(TinyPPI.HdrType))">1002</ondown>
                 <ondown condition="String.IsEqual(Window(10000).Property(TinyPPI.HdrType),hdr10)">1005</ondown>
-                <ondown condition="String.Contains(Window(10000).Property(TinyPPI.HdrType),hlg)">1009</ondown>
                 <ondown condition="String.Contains(Window(10000).Property(TinyPPI.HdrType),dolby)">1012</ondown>
             </control>
 
-            <!-- Player Process Info (only) -->
+            <!-- Player Process Info (only): HDR10+ and HLG have no VS10 modes -->
             <control type="button" id="1001">
-                <visible>String.IsEqual(Window(10000).Property(TinyPPI.HdrType),hdr10plus)</visible>
+                <visible>String.IsEqual(Window(10000).Property(TinyPPI.HdrType),hdr10plus) | String.Contains(Window(10000).Property(TinyPPI.HdrType),hlg)</visible>
                 <left>35</left>
                 <top>275</top>
                 <width>400</width>
@@ -239,59 +237,6 @@
                     <texturenofocus colordiffuse="00FFFFFF" border="40">common/button-white.png</texturenofocus>
                     <texturefocus colordiffuse="$INFO[Window(10000).Property(TinyPPI.DialogFocusColor)]" border="40">common/button-white.png</texturefocus>
                     <onup>1006</onup>
-                    <ondown>1001</ondown>
-                </control>
-            </control>
-
-            <!-- HLG -->
-            <control type="group">
-                <visible>String.Contains(Window(10000).Property(TinyPPI.HdrType),hlg)</visible>
-                <control type="button" id="1009">
-                    <left>35</left>
-                    <top>235</top>
-                    <width>400</width>
-                    <height>80</height>
-                    <label>[B]HLG (Original)[/B]</label>
-                    <align>center</align>
-                    <font>font23_narrow</font>
-                    <textcolor>$INFO[Window(10000).Property(TinyPPI.DescriptionColor)]</textcolor>
-                    <selectedcolor>$INFO[Window(10000).Property(TinyPPI.DescriptionColor)]</selectedcolor>
-                    <focusedcolor>$INFO[Window(10000).Property(TinyPPI.DialogFocusTextColor)]</focusedcolor>
-                    <texturenofocus colordiffuse="00FFFFFF" border="40">common/button-white.png</texturenofocus>
-                    <texturefocus colordiffuse="$INFO[Window(10000).Property(TinyPPI.DialogFocusColor)]" border="40">common/button-white.png</texturefocus>
-                    <onup>1001</onup>
-                    <ondown>1010</ondown>
-                </control>
-                <control type="button" id="1010">
-                    <left>35</left>
-                    <top>315</top>
-                    <width>400</width>
-                    <height>80</height>
-                    <label>[B]HLG → SDR[/B]</label>
-                    <align>center</align>
-                    <font>font23_narrow</font>
-                    <textcolor>$INFO[Window(10000).Property(TinyPPI.DescriptionColor)]</textcolor>
-                    <selectedcolor>$INFO[Window(10000).Property(TinyPPI.DescriptionColor)]</selectedcolor>
-                    <focusedcolor>$INFO[Window(10000).Property(TinyPPI.DialogFocusTextColor)]</focusedcolor>
-                    <texturenofocus colordiffuse="00FFFFFF" border="40">common/button-white.png</texturenofocus>
-                    <texturefocus colordiffuse="$INFO[Window(10000).Property(TinyPPI.DialogFocusColor)]" border="40">common/button-white.png</texturefocus>
-                    <onup>1009</onup>
-                    <ondown>1011</ondown>
-                </control>
-                <control type="button" id="1011">
-                    <left>35</left>
-                    <top>395</top>
-                    <width>400</width>
-                    <height>80</height>
-                    <label>[B]HLG → Dolby Vision[/B]</label>
-                    <align>center</align>
-                    <font>font23_narrow</font>
-                    <textcolor>$INFO[Window(10000).Property(TinyPPI.DescriptionColor)]</textcolor>
-                    <selectedcolor>$INFO[Window(10000).Property(TinyPPI.DescriptionColor)]</selectedcolor>
-                    <focusedcolor>$INFO[Window(10000).Property(TinyPPI.DialogFocusTextColor)]</focusedcolor>
-                    <texturenofocus colordiffuse="00FFFFFF" border="40">common/button-white.png</texturenofocus>
-                    <texturefocus colordiffuse="$INFO[Window(10000).Property(TinyPPI.DialogFocusColor)]" border="40">common/button-white.png</texturefocus>
-                    <onup>1010</onup>
                     <ondown>1001</ondown>
                 </control>
             </control>


### PR DESCRIPTION
HLG is not a VS10 input -- original_hlg has said so in a comment since it was written, and all it does is turn VS10 off so the stream takes the standard HDR path.  The dialog and the dashboard did not agree: both drew HLG the same three buttons HDR10 gets, two of which (HLG -> SDR, HLG -> Dolby Vision) ask the driver for a conversion off an input it has no VS10 group for.

HLG now goes the way HDR10+ went in #62.  The dialog's HLG group is gone along with the navigation branches that reached it, and the player-process button switches to the centred "only" variant for HLG as it already does for HDR10+. _options_for answers HLG with no options through a shared _has_no_modes, which the page already reads as "draw no VS10 card", so the output line goes with the buttons for the length of an HLG stream.  HDR10 keeps its three.

original_hlg itself stays: it is the one thing here that is not a conversion, and a keymap can still use it through run_mode to clear a VS10 mode an earlier title left behind.  The output reading is left alone -- the conversion badge and the session's switch events are built from it and are not the VS10 card.